### PR TITLE
Pipeline v3：dynamic facial detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The toolbox supports four datasets, which are SCAMPS, UBFC, PURE and COHFACE. Ci
 For now, we only recommend training with PURE or SCAMPS due to the level of synchronization and volume of the dataset.
 * [SCAMPS](https://arxiv.org/abs/2206.04197)
   
-    * D. Mcudff, M. Wander, X. Liu, B. Hill, J. Hernandez, J. Lester, T. Baltrusaitis, "SCAMPS: Synthetics for Camera Measurement of Physiological Signals", Arxiv, 2022
+    * D. McDuff, M. Wander, X. Liu, B. Hill, J. Hernandez, J. Lester, T. Baltrusaitis, "SCAMPS: Synthetics for Camera Measurement of Physiological Signals", Arxiv, 2022
     * In order to use this dataset in a deep model, you should organize the files as follows:
     -----------------
          data/SCAMPS/Train/

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ _C.DATA.EXP_DATA_NAME = ''
 _C.DATA.CACHED_PATH = 'PreprocessedData'
 # Dataset name, coule be overwritten by command line argument
 _C.DATA.DATASET = ''
-_C.DATA.DO_PREPROCESS = False
+_C.DATA.DO_PREPROCESS = True
 _C.DATA.DATA_FORMAT = 'NDCHW'
 # -----------------------------------------------------------------------------
 # Data preprocessing
@@ -41,6 +41,7 @@ _C.DATA.PREPROCESS.CLIP_LENGTH = 180
 _C.DATA.PREPROCESS.DYNAMIC_DETECTION = True
 _C.DATA.PREPROCESS.DETECTION_LENGTH = 180
 _C.DATA.PREPROCESS.CROP_FACE = True
+_C.DATA.PREPROCESS.FACE_DETECT = True
 _C.DATA.PREPROCESS.LARGE_FACE_BOX = True
 _C.DATA.PREPROCESS.LARGER_BOX_SIZE = 1.5
 _C.DATA.PREPROCESS.W = 128

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -101,6 +101,7 @@ class BaseLoader(Dataset):
             config_preprocess.W,
             config_preprocess.H,
             config_preprocess.LARGE_FACE_BOX,
+            config_preprocess.FACE_DETECT,
             config_preprocess.CROP_FACE,
             config_preprocess.LARGER_BOX_SIZE)
         # data_type
@@ -159,20 +160,24 @@ class BaseLoader(Dataset):
         return result
 
     def resize(self, frames, danymic_det, det_length,
-               w, h, larger_box, crop_face, larger_box_size):
+               w, h, larger_box, face_detection, crop_face, larger_box_size):
         """Resizes each frame, crops the face area if flag is true."""
-        if danymic_det:
-            det_num = ceil(frames.shape[0] / det_length)
-        else:
-            det_num = 1
-        face_region = list()
-
-        for idx in range(det_num):
-            if crop_face:
-                face_region.append(self.facial_detection(frames[det_length*idx], larger_box,larger_box_size))
+        if face_detection:
+            if danymic_det:
+                det_num = ceil(frames.shape[0] / det_length)
             else:
-                face_region.append(frames[0])
-        face_region_all = np.asarray(face_region, dtype='int')
+                det_num = 1
+            face_region = list()
+            for idx in range(det_num):
+                if crop_face:
+                    face_region.append(self.facial_detection(frames[det_length*idx], larger_box,larger_box_size))
+                else:
+                    face_region.append(frames[0])
+            face_region_all = np.asarray(face_region, dtype='int')
+        else:
+            assert (danymic_det == False)           # danymic_det can be True only when face_detection is True.
+            face_region_all = [0, 0, frames[0].shape[0], frames[0].shape[1]]
+
         resize_frames = np.zeros((frames.shape[0], h, w, 3))
         for i in range(0, frames.shape[0]):
             frame = frames[i]

--- a/dataset/data_loader/PURELoader.py
+++ b/dataset/data_loader/PURELoader.py
@@ -59,8 +59,6 @@ class PURELoader(BaseLoader):
         for i in range(file_num):
             filename = os.path.split(data_dirs[i]['path'])[-1]
             saved_filename = data_dirs[i]['index']
-            if saved_filename not in [204, 705, 704, 501, 703, 904, 404, 702, 502, 706]:
-                continue
             frames = self.read_video(
                 os.path.join(
                     data_dirs[i]['path'],


### PR DESCRIPTION
Pipeline v3：①**Add dynamic facial detection part**. When preprocessing original data, it will use intermediate frames for every “detecetion_length” frames to do facial detection. You can change the setting in yamls:  DYNAMIC_DETECTION(True or False)  DYNAMIC_LENGTH（setting interval length） 		

②fix a bug about FACE_DETECT paramater . I find out that in last version, in _Baseloader.py_ function _resize_ : if face_detection=False, then  face_region = frames[0]. It's not reasonable, because face_region should be a vector with the size of [1,4]. The correcet one should be [0, 0, frames[0].shape[0], frames[0].shape[1]]. 