### PR TITLE
Neural Method Train Bug Fix

### DIFF
--- a/neural_methods/trainer/DeepPhysTrainer.py
+++ b/neural_methods/trainer/DeepPhysTrainer.py
@@ -29,7 +29,7 @@ class DeepPhysTrainer(BaseTrainer):
         self.model_dir = config.MODEL.MODEL_DIR
         self.model_file_name = config.TRAIN.MODEL_FILE_NAME
         self.batch_size = config.TRAIN.BATCH_SIZE
-        self.chunk_len = config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
         self.config = config
         self.best_epoch = 0
 

--- a/neural_methods/trainer/EfficientPhysTrainer.py
+++ b/neural_methods/trainer/EfficientPhysTrainer.py
@@ -32,7 +32,7 @@ class EfficientPhysTrainer(BaseTrainer):
         self.batch_size = config.TRAIN.BATCH_SIZE
         self.num_of_gpu = config.NUM_OF_GPU_TRAIN
         self.base_len = self.num_of_gpu * self.frame_depth
-        self.chunk_len = config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
         self.config = config
         self.best_epoch = 0
 

--- a/neural_methods/trainer/TscanTrainer.py
+++ b/neural_methods/trainer/TscanTrainer.py
@@ -31,7 +31,7 @@ class TscanTrainer(BaseTrainer):
         self.batch_size = config.TRAIN.BATCH_SIZE
         self.num_of_gpu = config.NUM_OF_GPU_TRAIN
         self.base_len = self.num_of_gpu * self.frame_depth
-        self.chunk_len = self.chunk_len
+        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
         self.config = config
         self.best_epoch = 0
 


### PR DESCRIPTION
Changed chunk len to be pulled from config.TRAIN.DATA.PREPROCESS instead of config.TEST.DATA.PREPROCESS. Validated w/ `$python main.py --config_file ./configs/PURE_PURE_UBFC_TSCAN_BASIC.yaml`. Partial output below:

====Training Epoch: 9====
Train epoch 9:  76%|███████████▍   | 99/130 [00:48<00:12,  2.43it/s, loss=0.553][10,   100] loss: 0.628
Train epoch 9: 100%|██████████████| 130/130 [01:00<00:00,  2.13it/s, loss=0.638]
===Validating===
Validation: 100%|███████████████████| 32/32 [00:12<00:00,  2.46it/s, loss=0.819]
Saved Model Path:  PreTrainedModels/PURE_SizeW72_SizeH72_ClipLength180_DataTypeNormalized_Standardized_LabelTypeNormalized_Large_boxTrue_Large_size1.5_Dyamic_DetFalse_det_len180/PURE_PURE_UBFC_tscan_Epoch9.pth
validation loss:  0.6809390801936388
Update best model! Best epoch: 9
Saved Model Path:  PreTrainedModels/PURE_SizeW72_SizeH72_ClipLength180_DataTypeNormalized_Standardized_LabelTypeNormalized_Large_boxTrue_Large_size1.5_Dyamic_DetFalse_det_len180/PURE_PURE_UBFC_tscan_Epoch9.pth
best trained epoch:9, min_val_loss:0.6809390801936388
===Testing===
Testing uses non-pretrained model!
PreTrainedModels/PURE_SizeW72_SizeH72_ClipLength180_DataTypeNormalized_Standardized_LabelTypeNormalized_Large_boxTrue_Large_size1.5_Dyamic_DetFalse_det_len180/PURE_PURE_UBFC_tscan_Epoch9.pth
FFT MAE (FFT Label):1.1846127717391304
FFT RMSE (FFT Label):2.662072398135089
FFT MAPE (FFT Label):1.4150349614177038
FFT Pearson (FFT Label):0.9926106746709421