### PR TITLE
Pure data split fix

### DIFF
--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -62,6 +62,9 @@ class BaseLoader(Dataset):
         """Returns data directories under the path."""
         return None
 
+    def get_data_subset(self, data_dirs, begin, end):
+        return None
+
     def preprocess_dataset(self, data_dirs, config_preprocess,begin,end):
         """Parses and preprocesses all data.
 

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -63,6 +63,8 @@ class BaseLoader(Dataset):
         return None
 
     def get_data_subset(self, data_dirs, begin, end):
+        """Returns a subset of data dirs, split with begin and end values, 
+        and ensures no overlapping subjects between splits"""
         return None
 
     def preprocess_dataset(self, data_dirs, config_preprocess,begin,end):

--- a/dataset/data_loader/PURELoader.py
+++ b/dataset/data_loader/PURELoader.py
@@ -49,14 +49,6 @@ class PURELoader(BaseLoader):
 
     def get_data(self, data_path):
         """Returns data directories under the path(For PURE dataset)."""
-        # data_dirs = glob.glob(data_path + os.sep + "*-*")
-        # if not data_dirs:
-        #     raise ValueError(self.name+ " dataset get data error!")
-        # dirs = list()
-        # for data_dir in data_dirs:
-        #     subject = os.path.split(data_dir)[-1].replace('-', '')
-        #     dirs.append({"index": int(subject), "path": data_dir})
-        # return dirs
 
         data_dirs = glob.glob(data_path + os.sep + "*-*")
         if not data_dirs:
@@ -71,6 +63,8 @@ class PURELoader(BaseLoader):
 
 
     def get_data_subset(self, data_dirs, begin, end):
+        """Returns a subset of data dirs, split with begin and end values, 
+        and ensures no overlapping subjects between splits"""
 
         # get info about the dataset: subject list and num vids per subject
         data_info = dict()
@@ -103,9 +97,6 @@ class PURELoader(BaseLoader):
             subj_files = data_info[subj_num]
             file_info_list += subj_files # add file information to file_list (tuple of fname, subj ID, trial num, chunk num)
         
-        # print('FILE LIST LENGTH', len(file_info_list))
-        # print(file_info_list)
-        # raise ValueError("GIRISH FORCE QUIT") # TO DO GIRISH
         return file_info_list
 
 

--- a/dataset/data_loader/PURELoader.py
+++ b/dataset/data_loader/PURELoader.py
@@ -94,8 +94,7 @@ class PURELoader(BaseLoader):
         subj_range = list(range(0,num_subjs))
         if (begin !=0 or end !=1):
             subj_range = list(range(int(begin*num_subjs), int(end*num_subjs)))
-            print(subj_range)
-        print('used subject ids:', [subj_list[i] for i in subj_range])
+        print('used subject ids for split:', [subj_list[i] for i in subj_range])
 
         # compile file list
         file_info_list = []
@@ -104,9 +103,9 @@ class PURELoader(BaseLoader):
             subj_files = data_info[subj_num]
             file_info_list += subj_files # add file information to file_list (tuple of fname, subj ID, trial num, chunk num)
         
-        print('FILE LIST LENGTH', len(file_info_list))
-        print(file_info_list)
-        raise ValueError("GIRISH FORCE QUIT") # TO DO GIRISH
+        # print('FILE LIST LENGTH', len(file_info_list))
+        # print(file_info_list)
+        # raise ValueError("GIRISH FORCE QUIT") # TO DO GIRISH
         return file_info_list
 
 
@@ -127,7 +126,7 @@ class PURELoader(BaseLoader):
             frames, bvps, config_preprocess, config_preprocess.LARGE_FACE_BOX)
         count, input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
 
-    def preprocess_dataset(self, data_dirs, config_preprocess,begin, end):
+    def preprocess_dataset(self, data_dirs, config_preprocess, begin, end):
         """Preprocesses the raw data."""
         file_num = len(data_dirs)
         print("file_num:", file_num)
@@ -145,7 +144,7 @@ class PURELoader(BaseLoader):
         running_num = 0
         for i in choose_range:
             process_flag = True
-            while process_flag:         # ensure that every i creates a process
+            while process_flag:            # ensure that every i creates a process
                 if running_num < 16:       # in case of too many processes
                     p = Process(target=self.preprocess_dataset_subprocess, args=(data_dirs,config_preprocess,i))
                     p.start()


### PR DESCRIPTION
Added get_data_subset helper function to PURE data loader. This interfaces with the get_data function. The PURE data loader now ensures thats there is no subject overlap between data splits (train/val/test). The helper function may be used to improve other dataloaders that have multiple trials per individual (eg. COHFACE). 

The function of this change was tested with the following command:
$python main.py --config_file ../configs/PURE_PURE_UBFC_TSCAN_BASIC.yaml

It should also be noted that preprocessing was enabled for both PURE train and validation sets. 
The final portion of the train/test output can be seen below:

====Training Epoch: 9====
Train epoch 9:  77%|███████████▌   | 99/129 [00:44<00:11,  2.61it/s, loss=0.559][10,   100] loss: 0.655
Train epoch 9: 100%|██████████████| 129/129 [00:55<00:00,  2.31it/s, loss=0.612]
===Validating===
Validation: 100%|████████████████████| 34/34 [00:09<00:00,  3.51it/s, loss=0.43]
Saved Model Path:  PreTrainedModels/PURE_SizeW72_SizeH72_ClipLength180_DataTypeNormalized_Standardized_LabelTypeNormalized_Large_boxTrue_Large_size1.5_Dyamic_DetFalse_det_len180/PURE_PURE_UBFC_tscan_Epoch9.pth
validation loss:  0.6434635905658498
best trained epoch:5, min_val_loss:0.6389700279516333
===Testing===
Testing uses non-pretrained model!
PreTrainedModels/PURE_SizeW72_SizeH72_ClipLength180_DataTypeNormalized_Standardized_LabelTypeNormalized_Large_boxTrue_Large_size1.5_Dyamic_DetFalse_det_len180/PURE_PURE_UBFC_tscan_Epoch5.pth
FFT MAE (FFT Label):1.5667459239130435
FFT RMSE (FFT Label):3.2319068072410806
FFT MAPE (FFT Label):1.9091061076627633
FFT Pearson (FFT Label):0.9909906631057575
