### PR TITLE
changing scamps naming convention from Synthetics to SCAMPS

### DIFF
--- a/configs/SCAMPS_SCAMPS_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_PURE_DEEPPHYS_BASIC.yaml
@@ -7,7 +7,7 @@ TRAIN:
   MODEL_FILE_NAME: SCAMPS_SCAMPS_PURE_deepphys
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
@@ -30,7 +30,7 @@ TRAIN:
 VALID:
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated

--- a/configs/SCAMPS_SCAMPS_PURE_PHYSNET_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_PURE_PHYSNET_BASIC.yaml
@@ -7,7 +7,7 @@ TRAIN:
   MODEL_FILE_NAME: SCAMPS_SCAMPS_PURE_physnet
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NCDHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
@@ -30,7 +30,7 @@ TRAIN:
 VALID:
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NCDHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated

--- a/configs/SCAMPS_SCAMPS_PURE_TSCAN_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_PURE_TSCAN_BASIC.yaml
@@ -7,7 +7,7 @@ TRAIN:
   MODEL_FILE_NAME: SCAMPS_SCAMPS_PURE_tscan
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
@@ -30,7 +30,7 @@ TRAIN:
 VALID:
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated

--- a/configs/SCAMPS_SCAMPS_UBFC_DEEPPHYS_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_UBFC_DEEPPHYS_BASIC.yaml
@@ -7,7 +7,7 @@ TRAIN:
   MODEL_FILE_NAME: SCAMPS_SCAMPS_UBFC_deepphys
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
@@ -30,7 +30,7 @@ TRAIN:
 VALID:
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated

--- a/configs/SCAMPS_SCAMPS_UBFC_PHYSNET_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_UBFC_PHYSNET_BASIC.yaml
@@ -7,7 +7,7 @@ TRAIN:
   MODEL_FILE_NAME: SCAMPS_SCAMPS_UBFC_physnet
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NCDHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
@@ -30,7 +30,7 @@ TRAIN:
 VALID:
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NCDHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated

--- a/configs/SCAMPS_SCAMPS_UBFC_TSCAN_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_UBFC_TSCAN_BASIC.yaml
@@ -7,7 +7,7 @@ TRAIN:
   MODEL_FILE_NAME: SCAMPS_SCAMPS_UBFC_tscan
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
@@ -30,7 +30,7 @@ TRAIN:
 VALID:
   DATA:
     FS: 30
-    DATASET: SYNTHETICS
+    DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -46,7 +46,7 @@ class BaseLoader(Dataset):
         assert (config_data.END < 1 or config_data.END == 1)
         if config_data.BEGIN != 0 or config_data.END !=1:
             self.cached_path = config_data.CACHED_PATH + "_"+ str(config_data.BEGIN) + '_'+str(config_data.END)
-        elif config_data.DATASET == "SYNTHETICS":
+        elif config_data.DATASET == "SCAMPS":
             self.cached_path = config_data.CACHED_PATH + "_" + self.name
         print(self.cached_path)
         self.inputs = list()
@@ -242,7 +242,7 @@ class BaseLoader(Dataset):
     def save(self, frames_clips, bvps_clips, filename):
         """Saves the preprocessing data."""
         if not os.path.exists(self.cached_path):
-            os.makedirs(self.cached_path)
+            os.makedirs(self.cached_path, exist_ok=True)
         count = 0
         for i in range(len(bvps_clips)):
             assert (len(self.inputs) == len(self.labels))
@@ -261,7 +261,7 @@ class BaseLoader(Dataset):
     def save_multi_process(self, frames_clips, bvps_clips, filename):
         """Saves the preprocessing data."""
         if not os.path.exists(self.cached_path):
-            os.makedirs(self.cached_path)
+            os.makedirs(self.cached_path, exist_ok=True)
         count = 0
         input_path_name_list = []
         label_path_name_list = []

--- a/dataset/data_loader/SCAMPSLoader.py
+++ b/dataset/data_loader/SCAMPSLoader.py
@@ -24,7 +24,7 @@ class SCAMPSLoader(BaseLoader):
     """The data loader for the SCAMPS Processed dataset."""
 
     def __init__(self, name, data_path, config_data):
-        """Initializes an Processed dataloader.
+        """Initializes an SCAMPS Processed dataloader.
             Args:
                 data_path(string): path of a folder which stores raw video and ground truth biosignal in mat files.
                 Each mat file contains a video sequence of resolution of 72x72 and various ground trugh signal.

--- a/dataset/data_loader/SCAMPSLoader.py
+++ b/dataset/data_loader/SCAMPSLoader.py
@@ -20,11 +20,11 @@ from tqdm import tqdm
 from multiprocessing import Pool, Process, Value, Array, Manager
 import matplotlib.pyplot as plt
 
-class SyntheticsLoader(BaseLoader):
-    """The data loader for the SyntheticsProcessed dataset."""
+class SCAMPSLoader(BaseLoader):
+    """The data loader for the SCAMPS Processed dataset."""
 
     def __init__(self, name, data_path, config_data):
-        """Initializes an Synthetics Processed dataloader.
+        """Initializes an Processed dataloader.
             Args:
                 data_path(string): path of a folder which stores raw video and ground truth biosignal in mat files.
                 Each mat file contains a video sequence of resolution of 72x72 and various ground trugh signal.

--- a/dataset/data_loader/__init__.py
+++ b/dataset/data_loader/__init__.py
@@ -2,5 +2,5 @@ import dataset.data_loader.BaseLoader
 import dataset.data_loader.COHFACELoader
 import dataset.data_loader.UBFCLoader
 import dataset.data_loader.PURELoader
-import dataset.data_loader.SyntheticsLoader
+import dataset.data_loader.SCAMPSLoader
 

--- a/main.py
+++ b/main.py
@@ -133,8 +133,8 @@ if __name__ == "__main__":
             train_loader = data_loader.UBFCLoader.UBFCLoader
         elif config.TRAIN.DATA.DATASET == "PURE":
             train_loader = data_loader.PURELoader.PURELoader
-        elif config.TRAIN.DATA.DATASET == "SYNTHETICS":
-            train_loader = data_loader.SyntheticsLoader.SyntheticsLoader            
+        elif config.TRAIN.DATA.DATASET == "SCAMPS":
+            train_loader = data_loader.SCAMPSLoader.SCAMPSLoader            
         else:
             raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, and SCAMPS.")
 
@@ -146,8 +146,8 @@ if __name__ == "__main__":
             valid_loader = data_loader.UBFCLoader.UBFCLoader
         elif config.VALID.DATA.DATASET == "PURE":
             valid_loader = data_loader.PURELoader.PURELoader
-        elif config.VALID.DATA.DATASET == "SYNTHETICS":
-            valid_loader = data_loader.SyntheticsLoader.SyntheticsLoader
+        elif config.VALID.DATA.DATASET == "SCAMPS":
+            valid_loader = data_loader.SCAMPSLoader.SCAMPSLoader
         else:
             raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, and SCAMPS.")
 
@@ -159,8 +159,8 @@ if __name__ == "__main__":
             test_loader = data_loader.UBFCLoader.UBFCLoader
         elif config.TEST.DATA.DATASET == "PURE":
             test_loader = data_loader.PURELoader.PURELoader
-        elif config.TEST.DATA.DATASET == "SYNTHETICS":
-            test_loader = data_loader.SyntheticsLoader.SyntheticsLoader
+        elif config.TEST.DATA.DATASET == "SCAMPS":
+            test_loader = data_loader.SCAMPSLoader.SCAMPSLoader
         else:
             raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, and SCAMPS.")
 
@@ -221,8 +221,8 @@ if __name__ == "__main__":
             signal_loader = data_loader.UBFCLoader.UBFCLoader
         elif config.SIGNAL.DATA.DATASET == "PURE":
             signal_loader = data_loader.PURELoader.PURELoader
-        elif config.SIGNAL.DATA.DATASET == "SYNTHETICS":
-            signal_loader = data_loader.SyntheticsLoader.SyntheticsLoader
+        elif config.SIGNAL.DATA.DATASET == "SCAMPS":
+            signal_loader = data_loader.SCAMPSLoader.SCAMPSLoader
         else:
             raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, and SCAMPS.")
             


### PR DESCRIPTION
Edited the naming convention of SCAMPS from Synthetics to SCAMPS in ALL files.
This is verified for preprocessing, training, and test with the test SCAMPS_SCAMPS_SCAMPS_TSCAN_BASIC.