### PR TITLE
New file list feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Here are some explanation of parameters:
 * #### TRAIN / VALID / TEST / SIGNAL DATA: 
   * `DATA_PATH`: The input path of raw data
   * `CACHED_PATH`: The output path to preprocessed data
+  * `FILE_LIST_PATH`: The path at which the file list is stored. At this path a csv file is generated that lists the paths to all input data files used for the data split (train/val/test). If FILE_LIST_PATH is specified as a directory, a csv file list will be auto generated and auto-named (reflecting the preprocessing parameters) at this location. If FILE_LIST_PATH is specified as a csv file and preprocessing is turned on, a file list will be generated (or existing file overwritten) with name FILE_LIST_PATH. If FILE_LIST_PATH is specified as a csv file and preprocessing is turned off, this file (assuming it exists) will be used to load input data path-specified in the file. 
   * `EXP_DATA_NAME` If it is "", the toolbox generates a EXP_DATA_NAME based on other defined parameters. Otherwise, it uses the user-defined EXP_DATA_NAME.  
   * `BEGIN" & "END`: The portion of the dataset used for training/validation/testing. For example, if the `DATASET` is PURE, `BEGIN` is 0.0 and `END` is 0.8 under the TRAIN, the first 80% PURE is used for training the network. If the `DATASET` is PURE, `BEGIN` is 0.8 and `END` is 1.0 under the VALID, the last 20% PURE is used as the validation set. It is worth noting that validation and training sets don't have overlapping subjects.  
   * `DATA_TYPE`: How to preprocess the video data
@@ -75,7 +76,7 @@ Here are some explanation of parameters:
 * #### METRICS: Set used metrics. Example: ['MAE','RMSE','MAPE','Pearson']
 
 # Dataset
-The toolbox supports four datasets, which are SCAMPS, UBFC, PURE and COHFACE. Cite corresponding papers when using.
+The toolbox supports three datasets, which are SCAMPS, UBFC, and PURE (COHFACE support will be added shortly). Cite corresponding papers when using.
 For now, we only recommend training with PURE or SCAMPS due to the level of synchronization and volume of the dataset.
 * [SCAMPS](https://arxiv.org/abs/2206.04197)
   

--- a/config.py
+++ b/config.py
@@ -235,8 +235,8 @@ def update_config(config, args):
     if not ext: # no file extension
         config.TRAIN.DATA.FILE_LIST_PATH = os.path.join(config.TRAIN.DATA.FILE_LIST_PATH, \
                                                         config.TRAIN.DATA.EXP_DATA_NAME + '_' + \
-                                                        config.TRAIN.DATA.BEGIN+ '_' + \
-                                                        config.TRAIN.DATA.END + '.csv')
+                                                        str(config.TRAIN.DATA.BEGIN) + '_' + \
+                                                        str(config.TRAIN.DATA.END) + '.csv')
     elif ext != '.csv':
         raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
     
@@ -260,8 +260,8 @@ def update_config(config, args):
     if not ext: # no file extension
         config.VALID.DATA.FILE_LIST_PATH = os.path.join(config.VALID.DATA.FILE_LIST_PATH, \
                                                         config.VALID.DATA.EXP_DATA_NAME + '_' + \
-                                                        config.VALID.DATA.BEGIN+ '_' + \
-                                                        config.VALID.DATA.END + '.csv')
+                                                        str(config.VALID.DATA.BEGIN) + '_' + \
+                                                        str(config.VALID.DATA.END) + '.csv')
     elif ext != '.csv':
         raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
 
@@ -285,8 +285,8 @@ def update_config(config, args):
     if not ext: # no file extension
         config.TEST.DATA.FILE_LIST_PATH = os.path.join(config.TEST.DATA.FILE_LIST_PATH, \
                                                        config.TEST.DATA.EXP_DATA_NAME + '_' + \
-                                                       config.TEST.DATA.BEGIN+ '_' + \
-                                                       config.TEST.DATA.END + '.csv')
+                                                       str(config.TEST.DATA.BEGIN) + '_' + \
+                                                       str(config.TEST.DATA.END) + '.csv')
     elif ext != '.csv':
         raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
 
@@ -311,8 +311,8 @@ def update_config(config, args):
     if not ext: # no file extension
         config.SIGNAL.DATA.FILE_LIST_PATH = os.path.join(config.SIGNAL.DATA.FILE_LIST_PATH, \
                                                          config.SIGNAL.DATA.EXP_DATA_NAME + '_' + \
-                                                         config.SIGNAL.DATA.BEGIN+ '_' + \
-                                                         config.SIGNAL.DATA.END + '.csv')
+                                                         str(config.SIGNAL.DATA.BEGIN) + '_' + \
+                                                         str(config.SIGNAL.DATA.END) + '.csv')
     elif ext != '.csv':
         raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
 

--- a/config.py
+++ b/config.py
@@ -257,7 +257,7 @@ def update_config(config, args):
     config.VALID.DATA.CACHED_PATH = os.path.join(config.VALID.DATA.CACHED_PATH, config.VALID.DATA.EXP_DATA_NAME)
 
     name, ext = os.path.splitext(config.VALID.DATA.FILE_LIST_PATH)
-    if not ext: # no file extension
+    if not ext:  # no file extension
         config.VALID.DATA.FILE_LIST_PATH = os.path.join(config.VALID.DATA.FILE_LIST_PATH, \
                                                         config.VALID.DATA.EXP_DATA_NAME + '_' + \
                                                         str(config.VALID.DATA.BEGIN) + '_' + \

--- a/config.py
+++ b/config.py
@@ -36,6 +36,7 @@ _C.TRAIN.DATA.FS = 0
 _C.TRAIN.DATA.DATA_PATH = ''
 _C.TRAIN.DATA.EXP_DATA_NAME = ''
 _C.TRAIN.DATA.CACHED_PATH = 'PreprocessedData'
+_C.TRAIN.DATA.FILE_LIST_PATH = "DataFileLists"
 _C.TRAIN.DATA.DATASET = ''
 _C.TRAIN.DATA.DO_PREPROCESS = False
 _C.TRAIN.DATA.DATA_FORMAT = 'NDCHW'
@@ -64,6 +65,7 @@ _C.VALID.DATA.FS = 0
 _C.VALID.DATA.DATA_PATH = ''
 _C.VALID.DATA.EXP_DATA_NAME = ''
 _C.VALID.DATA.CACHED_PATH = 'PreprocessedData'
+_C.VALID.DATA.FILE_LIST_PATH = "DataFileLists"
 _C.VALID.DATA.DATASET = ''
 _C.VALID.DATA.DO_PREPROCESS = False
 _C.VALID.DATA.DATA_FORMAT = 'NDCHW'
@@ -95,6 +97,7 @@ _C.TEST.DATA.FS = 0
 _C.TEST.DATA.DATA_PATH = ''
 _C.TEST.DATA.EXP_DATA_NAME = ''
 _C.TEST.DATA.CACHED_PATH = 'PreprocessedData'
+_C.TEST.DATA.FILE_LIST_PATH = "DataFileLists"
 _C.TEST.DATA.DATASET = ''
 _C.TEST.DATA.DO_PREPROCESS = False
 _C.TEST.DATA.DATA_FORMAT = 'NDCHW'
@@ -126,6 +129,7 @@ _C.SIGNAL.DATA.FS = 0
 _C.SIGNAL.DATA.DATA_PATH = ''
 _C.SIGNAL.DATA.EXP_DATA_NAME = ''
 _C.SIGNAL.DATA.CACHED_PATH = 'PreprocessedData'
+_C.SIGNAL.DATA.FILE_LIST_PATH = "DataFileLists"
 _C.SIGNAL.DATA.DATASET = ''
 _C.SIGNAL.DATA.DO_PREPROCESS = False
 _C.SIGNAL.DATA.DATA_FORMAT = 'NDCHW'
@@ -227,6 +231,19 @@ def update_config(config, args):
                                               ])
     config.TRAIN.DATA.CACHED_PATH = os.path.join(config.TRAIN.DATA.CACHED_PATH, config.TRAIN.DATA.EXP_DATA_NAME)
 
+    name, ext = os.path.splitext(config.TRAIN.DATA.FILE_LIST_PATH)
+    if not ext: # no file extension
+        config.TRAIN.DATA.FILE_LIST_PATH = os.path.join(config.TRAIN.DATA.FILE_LIST_PATH, \
+                                                        config.TRAIN.DATA.EXP_DATA_NAME + '_' + \
+                                                        config.TRAIN.DATA.BEGIN+ '_' + \
+                                                        config.TRAIN.DATA.END + '.csv')
+    elif ext != '.csv':
+        raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
+    
+    if ext == '.csv' and config.TRAIN.DATA.DO_PREPROCESS:
+        raise ValueError(self.name, 'User specified FILE_LIST_PATH .csv file already exists. \
+                         Please turn DO_PREPROCESS to False or delete existing FILE_LIST_PATH .csv file.')
+
     if config.VALID.DATA.EXP_DATA_NAME == '':
         config.VALID.DATA.EXP_DATA_NAME = "_".join([config.VALID.DATA.DATASET, "SizeW{0}".format(
             str(config.VALID.DATA.PREPROCESS.W)), "SizeH{0}".format(str(config.VALID.DATA.PREPROCESS.W)), "ClipLength{0}".format(
@@ -236,9 +253,21 @@ def update_config(config, args):
                                       "Large_size{0}".format(config.VALID.DATA.PREPROCESS.LARGE_BOX_COEF),
                                       "Dyamic_Det{0}".format(config.VALID.DATA.PREPROCESS.DYNAMIC_DETECTION),
                                         "det_len{0}".format(config.VALID.DATA.PREPROCESS.DYNAMIC_DETECTION_FREQUENCY )
-
                                               ])
     config.VALID.DATA.CACHED_PATH = os.path.join(config.VALID.DATA.CACHED_PATH, config.VALID.DATA.EXP_DATA_NAME)
+
+    name, ext = os.path.splitext(config.VALID.DATA.FILE_LIST_PATH)
+    if not ext: # no file extension
+        config.VALID.DATA.FILE_LIST_PATH = os.path.join(config.VALID.DATA.FILE_LIST_PATH, \
+                                                        config.VALID.DATA.EXP_DATA_NAME + '_' + \
+                                                        config.VALID.DATA.BEGIN+ '_' + \
+                                                        config.VALID.DATA.END + '.csv')
+    elif ext != '.csv':
+        raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
+
+    if ext == '.csv' and config.VALID.DATA.DO_PREPROCESS:
+        raise ValueError(self.name, 'User specified FILE_LIST_PATH .csv file already exists. \
+                         Please turn DO_PREPROCESS to False or delete existing FILE_LIST_PATH .csv file.')
 
     if config.TEST.DATA.EXP_DATA_NAME == '':
         config.TEST.DATA.EXP_DATA_NAME = "_".join([config.TEST.DATA.DATASET, "SizeW{0}".format(
@@ -251,6 +280,19 @@ def update_config(config, args):
                                         "det_len{0}".format(config.TEST.DATA.PREPROCESS.DYNAMIC_DETECTION_FREQUENCY )
                                               ])
     config.TEST.DATA.CACHED_PATH = os.path.join(config.TEST.DATA.CACHED_PATH, config.TEST.DATA.EXP_DATA_NAME)
+
+    name, ext = os.path.splitext(config.TEST.DATA.FILE_LIST_PATH)
+    if not ext: # no file extension
+        config.TEST.DATA.FILE_LIST_PATH = os.path.join(config.TEST.DATA.FILE_LIST_PATH, \
+                                                       config.TEST.DATA.EXP_DATA_NAME + '_' + \
+                                                       config.TEST.DATA.BEGIN+ '_' + \
+                                                       config.TEST.DATA.END + '.csv')
+    elif ext != '.csv':
+        raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
+
+    if ext == '.csv' and config.TEST.DATA.DO_PREPROCESS:
+        raise ValueError(self.name, 'User specified FILE_LIST_PATH .csv file already exists. \
+                         Please turn DO_PREPROCESS to False or delete existing FILE_LIST_PATH .csv file.')
     
     if config.SIGNAL.DATA.EXP_DATA_NAME == '':
         config.SIGNAL.DATA.EXP_DATA_NAME = "_".join([config.SIGNAL.DATA.DATASET, "SizeW{0}".format(
@@ -264,6 +306,20 @@ def update_config(config, args):
                                         "signal"
                                               ])
     config.SIGNAL.DATA.CACHED_PATH = os.path.join(config.SIGNAL.DATA.CACHED_PATH, config.SIGNAL.DATA.EXP_DATA_NAME)
+
+    name, ext = os.path.splitext(config.SIGNAL.DATA.FILE_LIST_PATH)
+    if not ext: # no file extension
+        config.SIGNAL.DATA.FILE_LIST_PATH = os.path.join(config.SIGNAL.DATA.FILE_LIST_PATH, \
+                                                         config.SIGNAL.DATA.EXP_DATA_NAME + '_' + \
+                                                         config.SIGNAL.DATA.BEGIN+ '_' + \
+                                                         config.SIGNAL.DATA.END + '.csv')
+    elif ext != '.csv':
+        raise ValueError(self.name, 'FILE_LIST_PATH must either be a directory path or a .csv file name')
+
+    if ext == '.csv' and config.SIGNAL.DATA.DO_PREPROCESS:
+        raise ValueError(self.name, 'User specified FILE_LIST_PATH .csv file already exists. \
+                         Please turn DO_PREPROCESS to False or delete existing FILE_LIST_PATH .csv file.')
+
 
     config.LOG.PATH = os.path.join(
         config.LOG.PATH, config.VALID.DATA.EXP_DATA_NAME)

--- a/configs/PURE_PURE_UBFC_DEEPPHYS_BASIC.yaml
+++ b/configs/PURE_PURE_UBFC_DEEPPHYS_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: PURE
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"       # need to be updated
+    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"          # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -33,8 +34,9 @@ VALID:
     DATASET: PURE
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH: "/data1/toolbox_data/PURE/RawData"   # need to be updated
+    DATA_PATH: "/data1/toolbox_data/PURE/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: UBFC
     DO_PREPROCESS: False                    # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"     # need to be updated
+    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/PURE_PURE_UBFC_EFFICIENTPHYS.yaml
+++ b/configs/PURE_PURE_UBFC_EFFICIENTPHYS.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: PURE
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/PURE/RawData"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/PURE/RawData"                     # Raw dataset path, need to be updated
     CACHED_PATH: "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/rppg_toolbox/PreprocessedData"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/rppg_toolbox/DataFileLists/"   # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -33,8 +34,9 @@ VALID:
     DATASET: PURE
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/PURE/RawData"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/PURE/RawData"                     # Raw dataset path, need to be updated
     CACHED_PATH: "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/rppg_toolbox/PreprocessedData"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/rppg_toolbox/DataFileLists/"   # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: UBFC
     DO_PREPROCESS: False                    # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/UBFC/RawData"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/UBFC/RawData"                     # Raw dataset path, need to be updated
     CACHED_PATH: "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/rppg_toolbox/PreprocessedData"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/gscratch/ubicomp/xliu0/data3/mnt/Datasets/rppg_toolbox/DataFileLists/"   # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/PURE_PURE_UBFC_PHYSNET_BASIC.yaml
+++ b/configs/PURE_PURE_UBFC_PHYSNET_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: PURE
     DO_PREPROCESS: True            # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"       # need to be updated
+    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"          # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -33,8 +34,9 @@ VALID:
     DATASET: PURE
     DO_PREPROCESS: True                # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH: "/data1/toolbox_data/PURE/RawData"   # need to be updated
+    DATA_PATH: "/data1/toolbox_data/PURE/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: UBFC
     DO_PREPROCESS: True                  # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"     # need to be updated
+    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/PURE_PURE_UBFC_TSCAN_BASIC.yaml
+++ b/configs/PURE_PURE_UBFC_TSCAN_BASIC.yaml
@@ -12,6 +12,7 @@ TRAIN:
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data1/toolbox_data/PURE/RawData"          # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -35,6 +36,7 @@ VALID:
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data1/toolbox_data/PURE/RawData"          # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -59,6 +61,7 @@ TEST:
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"          # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/PURE_SIGNAL.yaml
+++ b/configs/PURE_SIGNAL.yaml
@@ -8,8 +8,9 @@ SIGNAL:
     DATASET: PURE
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDHWC
-    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"       # need to be updated
+    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"                          # need to be updated
     CACHED_PATH: "/data1/acsp/Yuzhe_Zhang/rPPG-Toolbox/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data1/acsp/Yuzhe_Zhang/rPPG-Toolbox/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/SCAMPS_SCAMPS_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_PURE_DEEPPHYS_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
-    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"       # Raw dataset path, need to be updated
+    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"          # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"          # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -33,8 +34,9 @@ VALID:
     DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated
-    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"       # Raw dataset path, need to be updated
+    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"        # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"        # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -59,6 +61,7 @@ TEST:
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data1/toolbox_data/PURE/RawData"          # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/SCAMPS_SCAMPS_PURE_PHYSNET_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_PURE_PHYSNET_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"           # Raw dataset path, need to be updated
     CACHED_PATH: "/data4/acsp/Yuzhe_Zhang/PreprocessedData_backup/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data4/acsp/Yuzhe_Zhang/DataFileLists/"           # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -33,8 +34,9 @@ VALID:
     DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"             # Raw dataset path, need to be updated
     CACHED_PATH: "/data4/acsp/Yuzhe_Zhang/PreprocessedData_backup/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data4/acsp/Yuzhe_Zhang/DataFileLists/"           # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: PURE
     DO_PREPROCESS: True                    # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data1/toolbox_data/PURE/RawData"                    # Raw dataset path, need to be updated
     CACHED_PATH: "/data4/acsp/Yuzhe_Zhang/PreprocessedData_backup/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data4/acsp/Yuzhe_Zhang/DataFileLists/"           # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/SCAMPS_SCAMPS_PURE_TSCAN_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_PURE_TSCAN_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
-    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"    # Raw dataset path, need to be updated
+    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"       # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"       # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -33,8 +34,9 @@ VALID:
     DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"   # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -59,6 +61,7 @@ TEST:
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data1/toolbox_data/PURE/RawData"          # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/SCAMPS_SCAMPS_UBFC_DEEPPHYS_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_UBFC_DEEPPHYS_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
-    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"    # Raw dataset path, need to be updated
+    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"       # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"       # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -33,8 +34,9 @@ VALID:
     DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"   # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -59,6 +61,7 @@ TEST:
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"          # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/SCAMPS_SCAMPS_UBFC_PHYSNET_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_UBFC_PHYSNET_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"            # Raw dataset path, need to be updated
     CACHED_PATH: "/data4/acsp/Yuzhe_Zhang/PreprocessedData_backup/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data4/acsp/Yuzhe_Zhang/DataFileLists/"           # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -33,8 +34,9 @@ VALID:
     DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"             # Raw dataset path, need to be updated
     CACHED_PATH: "/data4/acsp/Yuzhe_Zhang/PreprocessedData_backup/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data4/acsp/Yuzhe_Zhang/DataFileLists/"           # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: UBFC
     DO_PREPROCESS: True                    # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"                    # Raw dataset path, need to be updated
     CACHED_PATH: "/data4/acsp/Yuzhe_Zhang/PreprocessedData_backup/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data4/acsp/Yuzhe_Zhang/DataFileLists/"           # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/SCAMPS_SCAMPS_UBFC_TSCAN_BASIC.yaml
+++ b/configs/SCAMPS_SCAMPS_UBFC_TSCAN_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: SCAMPS
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"          # Raw dataset path, need to be updated
-    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Train"    # Raw dataset path, need to be updated
+    CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"       # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"       # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -33,8 +34,9 @@ VALID:
     DATASET: SCAMPS
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"          # Raw dataset path, need to be updated
+    DATA_PATH:   "/data2/rppg_datasets/scamps/RawData/Val"   # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -59,6 +61,7 @@ TEST:
     DATA_FORMAT: NDCHW
     DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"          # Raw dataset path, need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/UBFC_SIGNAL.yaml
+++ b/configs/UBFC_SIGNAL.yaml
@@ -8,8 +8,9 @@ SIGNAL:
     DATASET: UBFC
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDHWC
-    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"       # need to be updated
+    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"                          # need to be updated
     CACHED_PATH: "/data1/acsp/Yuzhe_Zhang/rPPG-Toolbox/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data1/acsp/Yuzhe_Zhang/rPPG-Toolbox/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/UBFC_UBFC_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/UBFC_UBFC_PURE_DEEPPHYS_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: UBFC
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"       # need to be updated
+    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"          # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -33,8 +34,9 @@ VALID:
     DATASET: UBFC
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"   # need to be updated
+    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: PURE
     DO_PREPROCESS: False                    # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH: "/data1/toolbox_data/PURE/RawData"     # need to be updated
+    DATA_PATH: "/data1/toolbox_data/PURE/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/UBFC_UBFC_PURE_PHYSNET_BASIC.yaml
+++ b/configs/UBFC_UBFC_PURE_PHYSNET_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: UBFC
     DO_PREPROCESS: True            # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"       # need to be updated
+    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"          # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -33,8 +34,9 @@ VALID:
     DATASET: UBFC
     DO_PREPROCESS: True                # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"   # need to be updated
+    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: PURE
     DO_PREPROCESS: True                  # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH: "/data1/toolbox_data/PURE/RawData"     # need to be updated
+    DATA_PATH: "/data1/toolbox_data/PURE/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/configs/UBFC_UBFC_PURE_TSCAN_BASIC.yaml
+++ b/configs/UBFC_UBFC_PURE_TSCAN_BASIC.yaml
@@ -10,8 +10,9 @@ TRAIN:
     DATASET: UBFC
     DO_PREPROCESS: True               # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"       # need to be updated
+    DATA_PATH:   "/data1/toolbox_data/UBFC/RawData"          # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -33,8 +34,9 @@ VALID:
     DATASET: UBFC
     DO_PREPROCESS: True                  # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"   # need to be updated
+    DATA_PATH: "/data1/toolbox_data/UBFC/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -57,8 +59,9 @@ TEST:
     DATASET: PURE
     DO_PREPROCESS: True                    # if first time, should be true
     DATA_FORMAT: NDCHW
-    DATA_PATH: "/data1/toolbox_data/PURE/RawData"     # need to be updated
+    DATA_PATH: "/data1/toolbox_data/PURE/RawData"            # need to be updated
     CACHED_PATH: "/data2/rppg_datasets/PreprocessedData/"    # Processed dataset save path, need to be updated
+    FILE_LIST_PATH: "/data2/rppg_datasets/DataFileLists/"    # Path to store file lists, needs to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -7,6 +7,10 @@ Dataset already supported:UBFC,PURE and COHFACE
 import glob
 import os
 import re
+from multiprocessing import Pool, Process, Value, Array, Manager
+from tqdm import tqdm
+import pandas as pd
+import csv
 from math import ceil
 
 import cv2
@@ -45,10 +49,11 @@ class BaseLoader(Dataset):
         assert (config_data.BEGIN > 0 or config_data.BEGIN == 0)
         assert (config_data.END < 1 or config_data.END == 1)
         if config_data.BEGIN != 0 or config_data.END != 1:
-            self.cached_path = config_data.CACHED_PATH + "_" + str(config_data.BEGIN) + '_' + str(config_data.END)
+            self.cached_path = config_data.CACHED_PATH
         elif config_data.DATASET == "SCAMPS":
             self.cached_path = config_data.CACHED_PATH + "_" + self.name
         print(self.cached_path)
+        self.file_list_path = config_data.FILE_LIST_PATH
         self.inputs = list()
         self.labels = list()
         self.len = 0
@@ -74,7 +79,6 @@ class BaseLoader(Dataset):
 
         Args:
             config_preprocess(CfgNode): preprocessing settings(ref:config.py).
-
         """
         pass
 
@@ -267,18 +271,68 @@ class BaseLoader(Dataset):
             count += 1
         return count, input_path_name_list, label_path_name_list
 
+    def multi_process_manager(self, data_dirs, config_preprocess, choose_range):
+        # shared data resource
+        manager = Manager()
+        file_list_dict = manager.dict()
+
+        pbar = tqdm(list(choose_range))
+        p_list = []
+        running_num = 0
+        for i in choose_range:
+            process_flag = True
+            while process_flag:  # ensure that every i creates a process
+                if running_num < 16:  # in case of too many processes
+                    p = Process(target=self.preprocess_dataset_subprocess, \
+                                args=(data_dirs, config_preprocess, i, file_list_dict))
+                    p.start()
+                    p_list.append(p)
+                    running_num += 1
+                    process_flag = False
+                for p_ in p_list:
+                    if not p_.is_alive():
+                        p_list.remove(p_)
+                        p_.join()
+                        running_num -= 1
+                        pbar.update(1)
+        # join all processes
+        for p_ in p_list:
+            p_.join()
+            pbar.update(1)
+        pbar.close()
+
+        return file_list_dict
+
+    def build_file_list(self, file_list_dict, num_files):
+        """build file list"""
+
+        if len(file_list_dict.keys()) != num_files:
+            raise ValueError(self.name, 'All processed files not found')
+
+        file_list = []
+        for process_num, file_paths in file_list_dict.items():
+            file_list = file_list + file_paths
+
+        if not file_list:
+            raise ValueError(self.name, 'No files in file list')
+
+        file_list_df = pd.DataFrame(file_list, columns = ['input_files'])   
+        file_list_df.to_csv(self.file_list_path)
+
     def load(self):
-        """Loads the preprocessing data."""
-        inputs = glob.glob(os.path.join(self.cached_path, "*input*.npy"))
-        if not inputs:
+        """Loads the preprocessing data listed in the file list"""
+
+        file_list_path = self.file_list_path # get list of files in 
+        file_list_df = pd.read_csv(file_list_path) 
+
+        inputs = file_list_df['input_files'].tolist()
+        if inputs == []:
             raise ValueError(self.name + ' dataset loading data error!')
-        inputs = sorted(inputs)  # sort input file name list
-        labels = [input.replace("input", "label") for input in inputs]
-        assert (len(inputs) == len(labels))
+        labels = [input_file.replace("input", "label") for input_file in inputs]
         self.inputs = inputs
         self.labels = labels
         self.len = len(inputs)
-        print("loaded data len:", self.len)
+        print("Loaded data len:", self.len)
 
     @staticmethod
     def diff_normalize_data(data):

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -282,7 +282,7 @@ class BaseLoader(Dataset):
         for i in choose_range:
             process_flag = True
             while process_flag:  # ensure that every i creates a process
-                if running_num < 16:  # in case of too many processes
+                if running_num < 8:  # in case of too many processes
                     p = Process(target=self.preprocess_dataset_subprocess, \
                                 args=(data_dirs, config_preprocess, i, file_list_dict))
                     p.start()
@@ -317,6 +317,7 @@ class BaseLoader(Dataset):
             raise ValueError(self.name, 'No files in file list')
 
         file_list_df = pd.DataFrame(file_list, columns = ['input_files'])   
+        os.makedirs(os.path.dirname(self.file_list_path), exist_ok=True)
         file_list_df.to_csv(self.file_list_path)
 
     def load(self):
@@ -328,6 +329,7 @@ class BaseLoader(Dataset):
         inputs = file_list_df['input_files'].tolist()
         if inputs == []:
             raise ValueError(self.name + ' dataset loading data error!')
+        inputs = sorted(inputs)  # sort input file name list
         labels = [input_file.replace("input", "label") for input_file in inputs]
         self.inputs = inputs
         self.labels = labels

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -45,20 +45,22 @@ class BaseLoader(Dataset):
         self.name = name
         self.data_path = data_path
         self.cached_path = config_data.CACHED_PATH
+        self.file_list_path = config_data.FILE_LIST_PATH
         assert (config_data.BEGIN < config_data.END)
         assert (config_data.BEGIN > 0 or config_data.BEGIN == 0)
         assert (config_data.END < 1 or config_data.END == 1)
-        if config_data.BEGIN != 0 or config_data.END != 1:
-            self.cached_path = config_data.CACHED_PATH
-        elif config_data.DATASET == "SCAMPS":
+        if config_data.DATASET == "SCAMPS":
             self.cached_path = config_data.CACHED_PATH + "_" + self.name
-        print(self.cached_path)
-        self.file_list_path = config_data.FILE_LIST_PATH
+            self.file_list_path = config_data.FILE_LIST_PATH[:-4] + "_" + self.name \
+                                  + config_data.FILE_LIST_PATH[-4:]
+        print('Cached Data Path', self.cached_path)
+        print('File List Path', self.file_list_path)
         self.inputs = list()
         self.labels = list()
         self.len = 0
         self.data_format = config_data.DATA_FORMAT
         data_dirs = self.get_data(self.data_path)
+        self.do_preprocess = config_data.DO_PREPROCESS
         if config_data.DO_PREPROCESS:
             self.preprocess_dataset(data_dirs, config_data.PREPROCESS, config_data.BEGIN, config_data.END)
         else:
@@ -324,8 +326,10 @@ class BaseLoader(Dataset):
         """Loads the preprocessing data listed in the file list"""
 
         file_list_path = self.file_list_path # get list of files in 
-        file_list_df = pd.read_csv(file_list_path) 
 
+        # TO DO: Insert functionality to generate file list if it does not already exist
+
+        file_list_df = pd.read_csv(file_list_path) 
         inputs = file_list_df['input_files'].tolist()
         if inputs == []:
             raise ValueError(self.name + ' dataset loading data error!')

--- a/dataset/data_loader/PURELoader.py
+++ b/dataset/data_loader/PURELoader.py
@@ -11,7 +11,6 @@ import glob
 import json
 import os
 import re
-from multiprocessing import Pool, Process, Value, Array, Manager
 
 import cv2
 import numpy as np
@@ -98,7 +97,7 @@ class PURELoader(BaseLoader):
 
         return file_info_list
 
-    def preprocess_dataset_subprocess(self, data_dirs, config_preprocess, i):
+    def preprocess_dataset_subprocess(self, data_dirs, config_preprocess, i, file_list_dict):
         """   invoked by preprocess_dataset for multi_process.   """
         filename = os.path.split(data_dirs[i]['path'])[-1]
         saved_filename = data_dirs[i]['index']
@@ -114,6 +113,7 @@ class PURELoader(BaseLoader):
         frames_clips, bvps_clips = self.preprocess(
             frames, bvps, config_preprocess, config_preprocess.LARGE_FACE_BOX)
         count, input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        file_list_dict[i] = input_name_list
 
     def preprocess_dataset(self, data_dirs, config_preprocess, begin, end):
         """Preprocesses the raw data."""
@@ -127,33 +127,9 @@ class PURELoader(BaseLoader):
             choose_range = range(0, len(data_dirs))
         print(choose_range)
 
-        pbar = tqdm(list(choose_range))
-        # multi_process
-        p_list = []
-        running_num = 0
-        for i in choose_range:
-            process_flag = True
-            while process_flag:  # ensure that every i creates a process
-                if running_num < 16:  # in case of too many processes
-                    p = Process(target=self.preprocess_dataset_subprocess, args=(data_dirs, config_preprocess, i))
-                    p.start()
-                    p_list.append(p)
-                    running_num += 1
-                    process_flag = False
-                for p_ in p_list:
-                    if not p_.is_alive():
-                        p_list.remove(p_)
-                        p_.join()
-                        running_num -= 1
-                        pbar.update(1)
-        # join all processes
-        for p_ in p_list:
-            p_.join()
-            pbar.update(1)
-        pbar.close()
-
-        # load all data and corresponding labels (sorted for consistency)
-        self.load()
+        file_list_dict = self.multi_process_manager(self, data_dirs, config_preprocess, choose_range)
+        self.build_file_list(self, file_list_dict, len(list(choose_range))) # build file list
+        self.load() # load all data and corresponding labels (sorted for consistency)
 
     @staticmethod
     def read_video(video_file):

--- a/dataset/data_loader/PURELoader.py
+++ b/dataset/data_loader/PURELoader.py
@@ -101,17 +101,14 @@ class PURELoader(BaseLoader):
         """   invoked by preprocess_dataset for multi_process.   """
         filename = os.path.split(data_dirs[i]['path'])[-1]
         saved_filename = data_dirs[i]['index']
+        
         frames = self.read_video(
-            os.path.join(
-                data_dirs[i]['path'],
-                filename, ""))
+            os.path.join(data_dirs[i]['path'], filename, ""))
         bvps = self.read_wave(
-            os.path.join(
-                data_dirs[i]['path'],
-                "{0}.json".format(filename)))
+            os.path.join(data_dirs[i]['path'], "{0}.json".format(filename)))
+
         bvps = sample(bvps, frames.shape[0])
-        frames_clips, bvps_clips = self.preprocess(
-            frames, bvps, config_preprocess, config_preprocess.LARGE_FACE_BOX)
+        frames_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess, config_preprocess.LARGE_FACE_BOX)
         count, input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
@@ -122,13 +119,12 @@ class PURELoader(BaseLoader):
         choose_range = range(0, file_num)
 
         if begin != 0 or end != 1:
-            # choose_range = range(int(begin * file_num), int(end * file_num))
             data_dirs = self.get_data_subset(data_dirs, begin, end)
             choose_range = range(0, len(data_dirs))
         print(choose_range)
 
-        file_list_dict = self.multi_process_manager(self, data_dirs, config_preprocess, choose_range)
-        self.build_file_list(self, file_list_dict, len(list(choose_range))) # build file list
+        file_list_dict = self.multi_process_manager(data_dirs, config_preprocess, choose_range)
+        self.build_file_list(file_list_dict, len(list(choose_range))) # build file list
         self.load() # load all data and corresponding labels (sorted for consistency)
 
     @staticmethod


### PR DESCRIPTION
Added file list functionality to dataloaders. 
This functionality generates a single preprocessed data folder for the entire dataset (of a single preprocess type), as opposed to splitting the processed dataset by percentages (eg. PURE_0.0_0.8 and PURE_0.8_1.0).

In addition to the preprocessed data folder, separate file lists, stored in csv files, are generated for each split of the dataset (eg. PURE_0.0_0.8.csv and PURE_0.8_1.0.csv).

This further allow individuals to specify a specific file list to source data from by changing the FILE_LIST_PATH.

A value, to be changed by the user, has been added to all of the config files. This value is FILE_LIST_PATH. 

Further work in this space requires adding functionaility, in the baseloader load function to generate file_lists if the pre-processed data already exists, but the file lists do not.


All work for this feature was validated on PURE_PURE_UBFC_TSCAN and SCAMPS_SCAMPS_SCAMPS_TSCAN