### PR TITLE
resolving issue w/ os specific separator

### DIFF
--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -115,7 +115,7 @@ class BaseLoader(Dataset):
         data = np.float32(data)
         label = np.float32(label)
         item_path = self.inputs[index]
-        item_path_filename = item_path.split('/')[-1]
+        item_path_filename = item_path.split(os.sep)[-1]
         split_idx = item_path_filename.index('_')
         filename = item_path_filename[:split_idx]
         chunk_id = item_path_filename[split_idx + 6:].split('.')[0]


### PR DESCRIPTION
addressing issue `Native Windows UBFC Testing gives an Error due to path splitting in DataLoader #106`
Changed os specific path separator in BaseLoader.py to os.sep. 

Confirmed proper function by running: 

python main --config_file PURE_PURE_UBFC_TSCAN_BASIC.yaml