### PR TITLE
Add explicit real part extraction when filtering BVP in ICA_POH

### DIFF
--- a/unsupervised_methods/methods/ICA_POH.py
+++ b/unsupervised_methods/methods/ICA_POH.py
@@ -41,7 +41,7 @@ def ICA_POH(frames, FS):
     MaxComp = np.argmax(MaxPx)
     BVP_I = S[MaxComp, :]
     B, A = signal.butter(3, [LPF / NyquistF, HPF / NyquistF], 'bandpass')
-    BVP_F = signal.filtfilt(B, A, BVP_I.astype(np.double))
+    BVP_F = signal.filtfilt(B, A, np.real(BVP_I).astype(np.double))
 
     BVP = BVP_F[0]
     return BVP


### PR DESCRIPTION
Pretty simple change to just explicitly extract the real part before casting. This change prevents the following warning message from appearing:

`/playpen/akshay/rPPG-Toolbox/unsupervised_methods/met
hods/ICA_POH.py:44: ComplexWarning: Casting complex values to real discards the imaginary part
  BVP_F = signal.filtfilt(B, A, BVP_I.astype(np.double))`