### PR TITLE
Use rindex instead of index for split_idx

### DIFF
--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -91,10 +91,19 @@ class BaseLoader(Dataset):
             raise ValueError('Unsupported Data Format!')
         data = np.float32(data)
         label = np.float32(label)
+        # item_path is the location of a specific clip in a preprocessing output folder
+        # For example, an item path could be /home/data/PURE_SizeW72_...unsupervised/501_input0.npy
         item_path = self.inputs[index]
+        # item_path_filename is simply the filename of the specific clip
+        # For example, the preceding item_path's filename would be 501_input0.npy
         item_path_filename = item_path.split(os.sep)[-1]
-        split_idx = item_path_filename.index('_')
+        # split_idx represents the point in the previous filename where we want to split the string 
+        # in order to retrieve a more precise filename (e.g., 501) preceding the chunk (e.g., input0)
+        split_idx = item_path_filename.rindex('_')
+        # Following the previous comments, the filename for example would be 501
         filename = item_path_filename[:split_idx]
+        # chunk_id is the extracted, numeric chunk identifier. Following the previous comments, 
+        # the chunk_id for example would be 0
         chunk_id = item_path_filename[split_idx + 6:].split('.')[0]
         return data, label, filename, chunk_id
 


### PR DESCRIPTION
As the title suggests. I think this makes more sense than how it currently is based on [how input files get saved in the first place](https://github.com/ubicomplab/rPPG-Toolbox/blob/main/dataset/data_loader/BaseLoader.py#L326). `rindex` basically finds the last occurrence of a specified value. Since input{chunk_id} is guaranteed to be at the end of the input filename, `rindex` makes more sense to use in case a passed in item_path_filename ever had more than one `_` in it and `index` returned an erroneous `split_idx` because it just happened to find the `_` in something like `subject_c`. 