### PR TITLE
`elif` makes the program fail to initialize test

### DIFF
--- a/main.py
+++ b/main.py
@@ -193,7 +193,7 @@ if __name__ == "__main__":
         else:
             data_loader_dict['valid'] = None
 
-    elif config.TOOLBOX_MODE == "train_and_test" or config.TOOLBOX_MODE == "only_test":
+    if config.TOOLBOX_MODE == "train_and_test" or config.TOOLBOX_MODE == "only_test":
         # test_loader
         if config.TEST.DATA.DATASET == "COHFACE":
             # test_loader = data_loader.COHFACELoader.COHFACELoader


### PR DESCRIPTION
`elif` makes the program fail to initialize test

here we can open it to initialize the test configuration

I think the proposal is to set the the program to run train only, but the following code with this elif would face the problem that it couldn't find the 'test' key error