### PR TITLE
Clean-up main.py and small fix in baseloader

### DIFF
--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -206,7 +206,7 @@ class BaseLoader(Dataset):
         """
 
         detector = cv2.CascadeClassifier(
-            '/data/rPPG-Toolbox_new/dataset/haarcascade_frontalface_default.xml')
+            './dataset/haarcascade_frontalface_default.xml')
         face_zone = detector.detectMultiScale(frame)
         if len(face_zone) < 1:
             print("ERROR: No Face Detected")

--- a/main.py
+++ b/main.py
@@ -138,10 +138,8 @@ if __name__ == "__main__":
             train_loader = data_loader.PURELoader.PURELoader
         elif config.TRAIN.DATA.DATASET == "SCAMPS":
             train_loader = data_loader.SCAMPSLoader.SCAMPSLoader
-        ###################################
         elif config.TRAIN.DATA.DATASET == "MMPD":
             train_loader = data_loader.MMPDLoader.MMPDLoader
-        ###################################
         else:
             raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, MMPD, and SCAMPS.")
 
@@ -155,37 +153,12 @@ if __name__ == "__main__":
             valid_loader = data_loader.PURELoader.PURELoader
         elif config.VALID.DATA.DATASET == "SCAMPS":
             valid_loader = data_loader.SCAMPSLoader.SCAMPSLoader
-        ###################################
         elif config.VALID.DATA.DATASET == "MMPD":
             valid_loader = data_loader.MMPDLoader.MMPDLoader
-        ###################################
         elif config.VALID.DATA.DATASET is None and not config.TEST.USE_LAST_EPOCH:
                 raise ValueError("Validation dataset not specified despite USE_LAST_EPOCH set to False!")
         else:
-            raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, MMPD, and SCAMPS.")
-
-        if config.TOOLBOX_MODE == "train_and_test" and config.TEST.USE_LAST_EPOCH:
-                print("Testing uses last epoch, validation dataset is not required.", end='\n\n')
-
-
-        # test_loader
-        if config.TEST.DATA.DATASET == "COHFACE":
-            # test_loader = data_loader.COHFACELoader.COHFACELoader
-            raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, MMPD, and SCAMPS.")
-        elif config.TEST.DATA.DATASET == "UBFC":
-            test_loader = data_loader.UBFCLoader.UBFCLoader
-        elif config.TEST.DATA.DATASET == "PURE":
-            test_loader = data_loader.PURELoader.PURELoader
-        elif config.TEST.DATA.DATASET == "SCAMPS":
-            test_loader = data_loader.SCAMPSLoader.SCAMPSLoader
-        ###################################
-        elif config.TEST.DATA.DATASET == "MMPD":
-            test_loader = data_loader.MMPDLoader.MMPDLoader
-        ###################################
-        else:
-            raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, MMPD, and SCAMPS.")
-
-        
+            raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, MMPD, and SCAMPS.")      
 
         # Create and initialize the train dataloader given the correct toolbox mode,
         # a supported dataset name, and a valid dataset path
@@ -237,9 +210,11 @@ if __name__ == "__main__":
             test_loader = data_loader.SCAMPSLoader.SCAMPSLoader
         elif config.TEST.DATA.DATASET == "MMPD":
             test_loader = data_loader.MMPDLoader.MMPDLoader
-        ###################################
         else:
             raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, MMPD, and SCAMPS.")
+
+        if config.TOOLBOX_MODE == "train_and_test" and config.TEST.USE_LAST_EPOCH:
+            print("Testing uses last epoch, validation dataset is not required.", end='\n\n')   
 
         # Create and initialize the test dataloader given the correct toolbox mode,
         # a supported dataset name, and a valid dataset path
@@ -270,10 +245,8 @@ if __name__ == "__main__":
             unsupervised_loader = data_loader.PURELoader.PURELoader
         elif config.UNSUPERVISED.DATA.DATASET == "SCAMPS":
             unsupervised_loader = data_loader.SCAMPSLoader.SCAMPSLoader
-        ###################################
         elif config.UNSUPERVISED.DATA.DATASET == "MMPD":
             unsupervised_loader = data_loader.MMPDLoader.MMPDLoader
-        ###################################
         else:
             raise ValueError("Unsupported dataset! Currently supporting UBFC, PURE, MMPD, and SCAMPS.")
 


### PR DESCRIPTION
As the title states. I've tested this PR using the inference config file UBFC_PURE_TSCAN_BASIC.yaml. I was able to 1) run inference successfully using existing preprocessed data folders, 2) preprocess PURE all over again with DO_PREPROCESS set to True and run inference successfully on it, and 3) run inference successfully using the newly created preprocessed data folder, with DO_PREPROCESS set to False. I got the same result below every time:

===Testing===                                                                                                                                                                                  
Testing uses pretrained model!                                                                                                                                                                 
                                                                                                                                                                                               
FFT MAE (FFT Label):3.694385593220339                                                                                                                                                          
FFT RMSE (FFT Label):13.848831292145585                                                                                                                                                        
FFT MAPE (FFT Label):3.3882176381266618                                                                                                                                                        
FFT Pearson (FFT Label):0.8176110623563922 

Also note the following for the test set length as reference:
test Preprocessed Dataset Length: 647 