### PR TITLE
Remove - 1 term from RGB normalization

### DIFF
--- a/unsupervised_methods/methods/CHROME_DEHAAN.py
+++ b/unsupervised_methods/methods/CHROME_DEHAAN.py
@@ -32,7 +32,7 @@ def CHROME_DEHAAN(frames,FS):
         RGBBase = np.mean(RGB[WinS:WinE, :], axis=0)
         RGBNorm = np.zeros((WinE-WinS, 3))
         for temp in range(WinS, WinE):
-            RGBNorm[temp-WinS] = np.true_divide(RGB[temp], RGBBase)-1
+            RGBNorm[temp-WinS] = np.true_divide(RGB[temp], RGBBase)
         Xs = np.squeeze(3*RGBNorm[:, 0]-2*RGBNorm[:, 1])
         Ys = np.squeeze(1.5*RGBNorm[:, 0]+RGBNorm[:, 1]-1.5*RGBNorm[:, 2])
         Xf = signal.filtfilt(B, A, Xs, axis=0)


### PR DESCRIPTION
This - 1 term doesn't change any of the current results and was pretty harmless to begin with since all it did was shift the normalized RGB distribution to be centered around 0, but to stay true to the original algorithm and as discussed in #139 I think it should be removed.

Result before removal:

FFT MAE (FFT Label):5.772477489406779
FFT RMSE (FFT Label):14.925515271353694
FFT MAPE (FFT Label):11.5169233509023
FFT Pearson  (FFT Label):0.809478372260371

Result after removal:

FFT MAE (FFT Label):5.772477489406779
FFT RMSE (FFT Label):14.925515271353694
FFT MAPE (FFT Label):11.5169233509023
FFT Pearson  (FFT Label):0.809478372260371