### PR TITLE
MMPD Fixes

### DIFF
--- a/configs/infer_configs/PURE_MMPD_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/PURE_MMPD_TSCAN_BASIC.yaml
@@ -46,5 +46,5 @@ MODEL:
 INFERENCE:
   BATCH_SIZE: 4
   EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
-  MODEL_PATH:   "/data/rPPG-Toolbox_MMPD/final_model_release/PURE_TSCAN.pth"
+  MODEL_PATH:   "./final_model_release/PURE_TSCAN.pth"
 

--- a/configs/infer_configs/SCAMPS_MMPD_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_MMPD_TSCAN_BASIC.yaml
@@ -46,4 +46,4 @@ MODEL:
 INFERENCE:
   BATCH_SIZE: 4
   EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
-  MODEL_PATH:   "/data/rPPG-Toolbox_MMPD/final_model_release/SCAMPS_TSCAN.pth"
+  MODEL_PATH:   "./final_model_release/SCAMPS_TSCAN.pth"

--- a/configs/infer_configs/UBFC_MMPD_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/UBFC_MMPD_TSCAN_BASIC.yaml
@@ -46,4 +46,4 @@ MODEL:
 INFERENCE:
   BATCH_SIZE: 4
   EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
-  MODEL_PATH:   "/data/rPPG-Toolbox_MMPD/final_model_release/UBFC_TSCAN.pth"
+  MODEL_PATH:   "./final_model_release/UBFC_TSCAN.pth"

--- a/dataset/data_loader/MMPDLoader.py
+++ b/dataset/data_loader/MMPDLoader.py
@@ -190,6 +190,9 @@ class MMPDLoader(BaseLoader):
             light = 3
         elif information[0] == 'Nature':
             light = 4
+        else:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! "
+            "The following lighting label is not supported: {0}".format(information[0]))
 
         motion = ''
         if information[1] == 'Stationary' or information[1] == 'Stationary (after exercise)':
@@ -198,40 +201,64 @@ class MMPDLoader(BaseLoader):
             motion = 2
         elif information[1] == 'Talking':
             motion = 3
-        elif information[1] == 'Walking':
+        # 'Watching Videos' is an erroneous label from older versions of the MMPD dataset, 
+        #  it should be handled as 'Walking'.
+        elif information[1] == 'Walking' or information[1] == 'Watching Videos':
             motion = 4
+        else:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! " 
+            "The following motion label is not supported: {0}".format(information[1]))
         
         exercise = ''
         if information[2] == 'True':
             exercise = 1
         elif information[2] == 'False':
             exercise = 2
+        else:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! "
+            "The following exercise label is not supported: {0}".format(information[2]))
 
         skin_color = information[3][0][0]
+
+        if skin_color != 3 and skin_color != 4 and skin_color != 5 and skin_color != 6:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! "
+            "The following skin_color label is not supported: {0}".format(information[3][0][0]))
 
         gender = ''
         if information[4] == 'male':
             gender = 1
         elif information[4] == 'female':
             gender = 2
+        else:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! "
+            "The following gender label is not supported: {0}".format(information[4]))
 
         glasser = ''
         if information[5] == 'True':
             glasser = 1
         elif information[5] == 'False':
             glasser = 2
+        else:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! "
+            "The following glasser label is not supported: {0}".format(information[5]))
 
         hair_cover = ''
         if information[6] == 'True':
             hair_cover = 1
         elif information[6] == 'False':
             hair_cover = 2
+        else:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! "
+            "The following hair_cover label is not supported: {0}".format(information[6]))
         
         makeup = ''
         if information[7] == 'True':
             makeup = 1
         elif information[7] == 'False':
             makeup = 2
+        else:
+            raise ValueError("Error with MMPD or Mini-MMPD dataset labels! "
+            "The following makeup label is not supported: {0}".format(information[7]))
 
         return light, motion ,exercise, skin_color, gender, glasser, hair_cover, makeup
 


### PR DESCRIPTION
Fix Mini-MMPD motion label error, add label error handling, and fix YAMLs

I generally added label error handling to the `MMPDLoader.py` file. Also fixed the associated YAML configs that use pre-trained models for testing - previously, the YAML config files used a pre-trained model file-path that would not work out-of-the-box for other toolbox users (including myself).

@McJackTang, my suspicion when you tested your previous PR (#134) is that you either used a different version of the MMPD dataset that you have locally and happens to have different motion labels, or perhaps there is some mistake in the labels in the MMPD dataset that was released and shared with dataset users via OneDrive and Baidu NetDisk. Either way, the error I ran into had to do with the motion labels for stationary motion not just being read as `Stationary` and `Stationary (after exercise)` as per the existing code in `MMPDLoader.py`, but also `Watching Videos`. My assumption is that `Watching Videos` also corresponds to a motion level of 1, or stationary motion type. Without the inclusion of `Watching Videos` as a potential label corresponding to the stationary motion type in this PR, users will encounter the same error I did and will be unable to use the dataset after pre-processing. The error ends up being encountered with this line when a motion label is not properly recognized and therefore an integer value is not present:

https://github.com/ubicomplab/rPPG-Toolbox/blob/b483b40217edaefc00de595dea83a99b58517681/dataset/data_loader/MMPDLoader.py#L162