### PR TITLE
Motion Aug Support

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@
 # Written by Ze Liu
 # --------------------------------------------------------'
 
-import os
+import os, re
 import yaml
 from yacs.config import CfgNode as CN
 
@@ -54,6 +54,9 @@ _C.TRAIN.DATA.END = 1.0
 # Train Data preprocessing
 _C.TRAIN.DATA.PREPROCESS = CN()
 _C.TRAIN.DATA.PREPROCESS.USE_PSUEDO_PPG_LABEL = False
+_C.TRAIN.DATA.PREPROCESS.DATA_TYPE = ['']
+_C.TRAIN.DATA.PREPROCESS.DATA_AUG = ['None']
+_C.TRAIN.DATA.PREPROCESS.LABEL_TYPE = ''
 _C.TRAIN.DATA.PREPROCESS.DO_CHUNK = True
 _C.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.TRAIN.DATA.PREPROCESS.CROP_FACE = CN()
@@ -67,8 +70,6 @@ _C.TRAIN.DATA.PREPROCESS.CROP_FACE.DETECTION.USE_MEDIAN_FACE_BOX = False
 _C.TRAIN.DATA.PREPROCESS.RESIZE = CN()
 _C.TRAIN.DATA.PREPROCESS.RESIZE.W = 128
 _C.TRAIN.DATA.PREPROCESS.RESIZE.H = 128
-_C.TRAIN.DATA.PREPROCESS.DATA_TYPE = ['']
-_C.TRAIN.DATA.PREPROCESS.LABEL_TYPE = ''
 # -----------------------------------------------------------------------------
 # Valid settings
 # -----------------------------------------------------------------------------\
@@ -97,6 +98,9 @@ _C.VALID.DATA.END = 1.0
 # Valid Data preprocessing
 _C.VALID.DATA.PREPROCESS = CN()
 _C.VALID.DATA.PREPROCESS.USE_PSUEDO_PPG_LABEL = False
+_C.VALID.DATA.PREPROCESS.DATA_TYPE = ['']
+_C.VALID.DATA.PREPROCESS.DATA_AUG = ['None']
+_C.VALID.DATA.PREPROCESS.LABEL_TYPE = ''
 _C.VALID.DATA.PREPROCESS.DO_CHUNK = True
 _C.VALID.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.VALID.DATA.PREPROCESS.CROP_FACE = CN()
@@ -110,9 +114,6 @@ _C.VALID.DATA.PREPROCESS.CROP_FACE.DETECTION.USE_MEDIAN_FACE_BOX = False
 _C.VALID.DATA.PREPROCESS.RESIZE = CN()
 _C.VALID.DATA.PREPROCESS.RESIZE.W = 128
 _C.VALID.DATA.PREPROCESS.RESIZE.H = 128
-_C.VALID.DATA.PREPROCESS.DATA_TYPE = ['']
-_C.VALID.DATA.PREPROCESS.LABEL_TYPE = ''
-
 
 # -----------------------------------------------------------------------------
 # Test settings
@@ -144,6 +145,9 @@ _C.TEST.DATA.END = 1.0
 # Test Data preprocessing
 _C.TEST.DATA.PREPROCESS = CN()
 _C.VALID.DATA.PREPROCESS.USE_PSUEDO_PPG_LABEL = False
+_C.TEST.DATA.PREPROCESS.DATA_TYPE = ['']
+_C.TEST.DATA.PREPROCESS.DATA_AUG = ['None']
+_C.TEST.DATA.PREPROCESS.LABEL_TYPE = ''
 _C.TEST.DATA.PREPROCESS.DO_CHUNK = True
 _C.TEST.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.TEST.DATA.PREPROCESS.CROP_FACE = CN()
@@ -157,8 +161,6 @@ _C.TEST.DATA.PREPROCESS.CROP_FACE.DETECTION.USE_MEDIAN_FACE_BOX = False
 _C.TEST.DATA.PREPROCESS.RESIZE = CN()
 _C.TEST.DATA.PREPROCESS.RESIZE.W = 128
 _C.TEST.DATA.PREPROCESS.RESIZE.H = 128
-_C.TEST.DATA.PREPROCESS.DATA_TYPE = ['']
-_C.TEST.DATA.PREPROCESS.LABEL_TYPE = ''
 
 # -----------------------------------------------------------------------------
 # Unsupervised method settings
@@ -189,6 +191,9 @@ _C.UNSUPERVISED.DATA.BEGIN = 0.0
 _C.UNSUPERVISED.DATA.END = 1.0
 # Unsupervised Data preprocessing
 _C.UNSUPERVISED.DATA.PREPROCESS = CN()
+_C.UNSUPERVISED.DATA.PREPROCESS.DATA_TYPE = ['']
+_C.UNSUPERVISED.DATA.PREPROCESS.DATA_AUG = ['None']
+_C.UNSUPERVISED.DATA.PREPROCESS.LABEL_TYPE = ''
 _C.UNSUPERVISED.DATA.PREPROCESS.DO_CHUNK = True
 _C.UNSUPERVISED.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE = CN()
@@ -202,8 +207,6 @@ _C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.DETECTION.USE_MEDIAN_FACE_BOX = False
 _C.UNSUPERVISED.DATA.PREPROCESS.RESIZE = CN()
 _C.UNSUPERVISED.DATA.PREPROCESS.RESIZE.W = 128
 _C.UNSUPERVISED.DATA.PREPROCESS.RESIZE.H = 128
-_C.UNSUPERVISED.DATA.PREPROCESS.DATA_TYPE = ['']
-_C.UNSUPERVISED.DATA.PREPROCESS.LABEL_TYPE = ''
 
 ### -----------------------------------------------------------------------------
 # Model settings
@@ -289,6 +292,7 @@ def update_config(config, args):
         config.TRAIN.DATA.EXP_DATA_NAME = "_".join([config.TRAIN.DATA.DATASET, "SizeW{0}".format(
             str(config.TRAIN.DATA.PREPROCESS.RESIZE.W)), "SizeH{0}".format(str(config.TRAIN.DATA.PREPROCESS.RESIZE.W)), "ClipLength{0}".format(
             str(config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH)), "DataType{0}".format("_".join(config.TRAIN.DATA.PREPROCESS.DATA_TYPE)),
+                                      "DataAug{0}".format("_".join(config.TRAIN.DATA.PREPROCESS.DATA_AUG)),
                                       "LabelType{0}".format(config.TRAIN.DATA.PREPROCESS.LABEL_TYPE),
                                       "Crop_face{0}".format(config.TRAIN.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
                                       "Large_box{0}".format(config.TRAIN.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),
@@ -321,6 +325,7 @@ def update_config(config, args):
             config.VALID.DATA.EXP_DATA_NAME = "_".join([config.VALID.DATA.DATASET, "SizeW{0}".format(
                 str(config.VALID.DATA.PREPROCESS.RESIZE.W)), "SizeH{0}".format(str(config.VALID.DATA.PREPROCESS.RESIZE.W)), "ClipLength{0}".format(
                 str(config.VALID.DATA.PREPROCESS.CHUNK_LENGTH)), "DataType{0}".format("_".join(config.VALID.DATA.PREPROCESS.DATA_TYPE)),
+                                        "DataAug{0}".format("_".join(config.VALID.DATA.PREPROCESS.DATA_AUG)),
                                         "LabelType{0}".format(config.VALID.DATA.PREPROCESS.LABEL_TYPE),
                                         "Crop_face{0}".format(config.VALID.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
                                         "Large_box{0}".format(config.VALID.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),
@@ -354,6 +359,7 @@ def update_config(config, args):
         config.TEST.DATA.EXP_DATA_NAME = "_".join([config.TEST.DATA.DATASET, "SizeW{0}".format(
             str(config.TEST.DATA.PREPROCESS.RESIZE.W)), "SizeH{0}".format(str(config.TEST.DATA.PREPROCESS.RESIZE.H)), "ClipLength{0}".format(
             str(config.TEST.DATA.PREPROCESS.CHUNK_LENGTH)), "DataType{0}".format("_".join(config.TEST.DATA.PREPROCESS.DATA_TYPE)),
+                                      "DataAug{0}".format("_".join(config.TEST.DATA.PREPROCESS.DATA_AUG)),
                                       "LabelType{0}".format(config.TEST.DATA.PREPROCESS.LABEL_TYPE),
                                       "Crop_face{0}".format(config.TEST.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
                                       "Large_box{0}".format(config.TEST.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),
@@ -378,6 +384,26 @@ def update_config(config, args):
                          Please turn DO_PREPROCESS to False or delete existing TEST dataset FILE_LIST_PATH .csv file.')
     
 
+    # UPDATE MODEL_FILE_NAME IF NEEDED
+    if any(aug != 'None' for aug in config.TRAIN.DATA.PREPROCESS.DATA_AUG + config.VALID.DATA.PREPROCESS.DATA_AUG + config.TEST.DATA.PREPROCESS.DATA_AUG):
+        # Check if the initial MODEL_FILE_NAME follows the expected pattern
+        if re.match(r'^[^_]+_[^_]+_[^_]+_[^_]+$', config.TRAIN.MODEL_FILE_NAME):
+            if 'Motion' in config.TRAIN.DATA.PREPROCESS.DATA_AUG:
+                model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
+                model_file_name_parts[0] = 'MA-' + model_file_name_parts[0]
+                config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)
+            if 'Motion' in config.VALID.DATA.PREPROCESS.DATA_AUG:
+                model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
+                model_file_name_parts[1] = 'MA-' + model_file_name_parts[1]
+                config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)
+            if 'Motion' in config.TEST.DATA.PREPROCESS.DATA_AUG:
+                model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
+                model_file_name_parts[2] = 'MA-' + model_file_name_parts[2]
+                config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)
+        else:
+            raise ValueError(f'MODEL_FILE_NAME does not follow expected naming pattern of [TRAIN_SET]_[VALID_SET]_[TEST_SET]! \
+                             \nReceived {config.TRAIN.MODEL_FILE_NAME}.')
+
     # UPDATE UNSUPERVISED PATHS
     if config.UNSUPERVISED.DATA.FILE_LIST_PATH == default_UNSUPERVISED_FILE_LIST_PATH:
         config.UNSUPERVISED.DATA.FILE_LIST_PATH = os.path.join(config.UNSUPERVISED.DATA.CACHED_PATH, 'DataFileLists')
@@ -386,6 +412,7 @@ def update_config(config, args):
         config.UNSUPERVISED.DATA.EXP_DATA_NAME = "_".join([config.UNSUPERVISED.DATA.DATASET, "SizeW{0}".format(
             str(config.UNSUPERVISED.DATA.PREPROCESS.RESIZE.W)), "SizeH{0}".format(str(config.UNSUPERVISED.DATA.PREPROCESS.RESIZE.W)), "ClipLength{0}".format(
             str(config.UNSUPERVISED.DATA.PREPROCESS.CHUNK_LENGTH)), "DataType{0}".format("_".join(config.UNSUPERVISED.DATA.PREPROCESS.DATA_TYPE)),
+                                      "DataAug{0}".format("_".join(config.UNSUPERVISED.DATA.PREPROCESS.DATA_AUG)),
                                       "LabelType{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.LABEL_TYPE),
                                       "Crop_face{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
                                       "Large_box{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),

--- a/config.py
+++ b/config.py
@@ -387,18 +387,27 @@ def update_config(config, args):
     # UPDATE MODEL_FILE_NAME IF NEEDED
     if any(aug != 'None' for aug in config.TRAIN.DATA.PREPROCESS.DATA_AUG + config.VALID.DATA.PREPROCESS.DATA_AUG + config.TEST.DATA.PREPROCESS.DATA_AUG):
         # Check if the initial MODEL_FILE_NAME follows the expected pattern
-        if re.match(r'^[^_]+_[^_]+_[^_]+_[^_]+$', config.TRAIN.MODEL_FILE_NAME):
+        if re.match(r'^[^_]+(_[^_]+)?(_[^_]+)?_[^_]+$', config.TRAIN.MODEL_FILE_NAME):
+            model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
+            if model_file_name_parts[2] == config.TEST.DATA.DATASET:
+                train_name_idx = 0
+                valid_name_idx = 1
+                test_name_idx = 2
+            else:
+                train_name_idx = 0
+                valid_name_idx = None
+                test_name_idx = 1
             if 'Motion' in config.TRAIN.DATA.PREPROCESS.DATA_AUG:
                 model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
-                model_file_name_parts[0] = 'MA-' + model_file_name_parts[0]
+                model_file_name_parts[train_name_idx] = 'MA-' + model_file_name_parts[train_name_idx]
                 config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)
-            if 'Motion' in config.VALID.DATA.PREPROCESS.DATA_AUG:
+            if 'Motion' in config.VALID.DATA.PREPROCESS.DATA_AUG and valid_name_part is not None:
                 model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
-                model_file_name_parts[1] = 'MA-' + model_file_name_parts[1]
+                model_file_name_parts[valid_name_idx] = 'MA-' + model_file_name_parts[valid_name_idx]
                 config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)
             if 'Motion' in config.TEST.DATA.PREPROCESS.DATA_AUG:
                 model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
-                model_file_name_parts[2] = 'MA-' + model_file_name_parts[2]
+                model_file_name_parts[test_name_idx] = 'MA-' + model_file_name_parts[test_name_idx]
                 config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)
         else:
             raise ValueError(f'MODEL_FILE_NAME does not follow expected naming pattern of [TRAIN_SET]_[VALID_SET]_[TEST_SET]! \

--- a/configs/infer_configs/PURE_UNSUPERVISED.yaml
+++ b/configs/infer_configs/PURE_UNSUPERVISED.yaml
@@ -13,8 +13,9 @@ UNSUPERVISED:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['Raw']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Raw
       DO_CHUNK: False
       CHUNK_LENGTH: 180

--- a/configs/infer_configs/UBFC_UNSUPERVISED.yaml
+++ b/configs/infer_configs/UBFC_UNSUPERVISED.yaml
@@ -13,8 +13,9 @@ UNSUPERVISED:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['Raw']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Raw
       DO_CHUNK: False
       CHUNK_LENGTH: 180

--- a/configs/train_configs/PURE_PURE_MMPD_TSCAN_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_MMPD_TSCAN_BASIC.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized','Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/configs/train_configs/PURE_PURE_UBFC_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC_DEEPPHYS_BASIC.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized','Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180
@@ -44,6 +45,7 @@ VALID:
     END: 1.0
     PREPROCESS:
       DATA_TYPE: [ 'DiffNormalized','Standardized' ]
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/configs/train_configs/PURE_PURE_UBFC_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC_EFFICIENTPHYS.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180
@@ -44,6 +45,7 @@ VALID:
     END: 1.0
     PREPROCESS:
       DATA_TYPE: ['Standardized' ]
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/configs/train_configs/PURE_PURE_UBFC_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC_PHYSNET_BASIC.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized']         #if use physnet, should be DiffNormalized
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 128                 #only support for factor of 512
@@ -42,8 +43,9 @@ VALID:
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized']         #if use physnet, should be DiffNormalized
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 128                 #only support for factor of 512
@@ -71,7 +73,7 @@ TEST:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized']         #if use physnet, should be DiffNormalized
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True

--- a/configs/train_configs/PURE_PURE_UBFC_TSCAN_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC_TSCAN_BASIC.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized','Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180
@@ -44,6 +45,7 @@ VALID:
     END: 1.0
     PREPROCESS:
       DATA_TYPE: [ 'DiffNormalized','Standardized' ]
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/configs/train_configs/UBFC_UBFC_MMPD_TSCAN_BASIC.yaml
+++ b/configs/train_configs/UBFC_UBFC_MMPD_TSCAN_BASIC.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized','Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180
@@ -44,6 +45,7 @@ VALID:
     END: 1.0
     PREPROCESS:
       DATA_TYPE: [ 'DiffNormalized','Standardized' ]
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/configs/train_configs/UBFC_UBFC_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/UBFC_UBFC_PURE_DEEPPHYS_BASIC.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized','Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180
@@ -44,6 +45,7 @@ VALID:
     END: 1.0
     PREPROCESS:
       DATA_TYPE: [ 'DiffNormalized','Standardized' ]
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/configs/train_configs/UBFC_UBFC_PURE_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/UBFC_UBFC_PURE_EFFICIENTPHYS.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180
@@ -44,6 +45,7 @@ VALID:
     END: 1.0
     PREPROCESS:
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/configs/train_configs/UBFC_UBFC_PURE_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/UBFC_UBFC_PURE_PHYSNET_BASIC.yaml
@@ -16,8 +16,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 128  #only support for factor of 512
@@ -44,8 +45,9 @@ VALID:
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 128  #only support for factor of 512
@@ -74,7 +76,7 @@ TEST:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True

--- a/configs/train_configs/UBFC_UBFC_PURE_TSCAN_BASIC.yaml
+++ b/configs/train_configs/UBFC_UBFC_PURE_TSCAN_BASIC.yaml
@@ -15,8 +15,9 @@ TRAIN:
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
-    PREPROCESS :
+    PREPROCESS:
       DATA_TYPE: ['DiffNormalized','Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180
@@ -44,6 +45,7 @@ VALID:
     END: 1.0
     PREPROCESS:
       DATA_TYPE: [ 'DiffNormalized','Standardized' ]
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: DiffNormalized
       DO_CHUNK: True
       CHUNK_LENGTH: 180

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -132,6 +132,12 @@ class BaseLoader(Dataset):
         """
         raise Exception("'split_raw_data' Not Implemented")
 
+    def read_npy_video(self, video_file):
+        """Reads a video file in the numpy format (.npy), returns frames(T,H,W,3)"""
+        frames = np.load(video_file[0])
+        frames = [(np.round(frame*255)).astype(np.uint8)[..., :3] for frame in frames]
+        return np.asarray(frames)
+
     def generate_pos_psuedo_labels(self, frames, fs=30):
         """Generated POS-based PPG Psuedo Labels For Training
 

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -135,8 +135,14 @@ class BaseLoader(Dataset):
     def read_npy_video(self, video_file):
         """Reads a video file in the numpy format (.npy), returns frames(T,H,W,3)"""
         frames = np.load(video_file[0])
-        frames = [(np.round(frame*255)).astype(np.uint8)[..., :3] for frame in frames]
-        return np.asarray(frames)
+        if np.issubdtype(frames.dtype, np.integer) and np.min(frames) >= 0 and np.max(frames) <= 255:
+            processed_frames = [frame.astype(np.uint8)[..., :3] for frame in frames]
+        elif np.issubdtype(frames.dtype, np.floating) and np.min(frames) >= 0.0 and np.max(frames) <= 1.0:
+            processed_frames = [(np.round(frame * 255)).astype(np.uint8)[..., :3] for frame in frames]
+        else:
+            raise Exception(f'Loaded frames are of an incorrect type or range of values! '\
+            + f'Received frames of type {frames.dtype} and range {np.min(frames)} to {np.max(frames)}.')
+        return np.asarray(processed_frames)
 
     def generate_pos_psuedo_labels(self, frames, fs=30):
         """Generated POS-based PPG Psuedo Labels For Training

--- a/dataset/data_loader/PURELoader.py
+++ b/dataset/data_loader/PURELoader.py
@@ -101,9 +101,17 @@ class PURELoader(BaseLoader):
         """ Invoked by preprocess_dataset for multi_process. """
         filename = os.path.split(data_dirs[i]['path'])[-1]
         saved_filename = data_dirs[i]['index']
-        
-        frames = self.read_video(
-            os.path.join(data_dirs[i]['path'], filename, ""))
+
+        if 'None' in config_preprocess.DATA_AUG:
+            # Utilize dataset-specific function to read video
+            frames = self.read_video(
+                os.path.join(data_dirs[i]['path'], filename, ""))
+        elif 'Motion' in config_preprocess.DATA_AUG:
+            # Utilize general function to read video in .npy format
+            frames = self.read_npy_video(
+                glob.glob(os.path.join(data_dirs[i]['path'], filename, '*.npy')))
+        else:
+            raise ValueError(f'Unsupported DATA_AUG specified for {self.dataset_name} dataset! Received {config_preprocess.DATA_AUG}.')
         bvps = self.read_wave(
             os.path.join(data_dirs[i]['path'], "{0}.json".format(filename)))
         target_length = frames.shape[0]

--- a/dataset/data_loader/UBFCLoader.py
+++ b/dataset/data_loader/UBFCLoader.py
@@ -69,8 +69,16 @@ class UBFCLoader(BaseLoader):
         filename = os.path.split(data_dirs[i]['path'])[-1]
         saved_filename = data_dirs[i]['index']
 
-        frames = self.read_video(
-            os.path.join(data_dirs[i]['path'],"vid.avi"))
+        if 'None' in config_preprocess.DATA_AUG:
+            # Utilize dataset-specific function to read video
+            frames = self.read_video(
+                os.path.join(data_dirs[i]['path'],"vid.avi"))
+        elif 'Motion' in config_preprocess.DATA_AUG:
+            # Utilize general function to read video in .npy format
+            frames = self.read_npy_video(
+                glob.glob(os.path.join(data_dirs[i]['path'],'*.npy')))
+        else:
+            raise ValueError(f'Unsupported DATA_AUG specified for {self.dataset_name} dataset! Received {config_preprocess.DATA_AUG}.')
         bvps = self.read_wave(
             os.path.join(data_dirs[i]['path'],"ground_truth.txt"))
             


### PR DESCRIPTION
This PR implements support for loading motion augmented datasets in a reasonably general way. Some changes made also will be useful for implementing future support for loading augmented data that is saved and generally working with augmented data. This is regardless of whether the data was augmented by another tool or augmented by this toolbox and saved, or if it's augmented at training time and the saved MODEL_FILE_NAMEs needs to reflect that.

I will update the README sometime this weekend to reflect these changes, as well as some of the other changes made to the config files (e.g., median bounding box option).

