### PR TITLE
Fix bug with variables in sample window code

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ After training, it will use the best model(with the least validation loss) to te
 
 STEP 1: Download the UBFC via [link](https://sites.google.com/view/ybenezeth/ubfcrppg)
 
-STEP 3: Modify `./configs/infer_configs/UBFC_UNSUPERVISED.yaml` 
+STEP 2: Modify `./configs/infer_configs/UBFC_UNSUPERVISED.yaml` 
 
-STEP 4: Run `python main.py --config_file ./configs/infer_configs/UBFC_UNSUPERVISED.yaml`
+STEP 3: Run `python main.py --config_file ./configs/infer_configs/UBFC_UNSUPERVISED.yaml`
 
 # :scroll: YAML File Setting
 The rPPG-Toolbox uses yaml file to control all parameters for training and evaluation. 

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -79,13 +79,13 @@ def calculate_metrics(predictions, labels, config):
             
             if config.INFERENCE.EVALUATION_METHOD == "peak detection":
                 gt_hr_peak, pred_hr_peak, SNR = calculate_metric_per_video(
-                    prediction, label, diff_flag=diff_flag_test, fs=config.TEST.DATA.FS, hr_method='Peak')
+                    pred_window, label_window, diff_flag=diff_flag_test, fs=config.TEST.DATA.FS, hr_method='Peak')
                 gt_hr_peak_all.append(gt_hr_peak)
                 predict_hr_peak_all.append(pred_hr_peak)
                 SNR_all.append(SNR)
             elif config.INFERENCE.EVALUATION_METHOD == "FFT":
                 gt_hr_fft, pred_hr_fft, SNR = calculate_metric_per_video(
-                    prediction, label, diff_flag=diff_flag_test, fs=config.TEST.DATA.FS, hr_method='FFT')
+                    pred_window, label_window, diff_flag=diff_flag_test, fs=config.TEST.DATA.FS, hr_method='FFT')
                 gt_hr_fft_all.append(gt_hr_fft)
                 predict_hr_fft_all.append(pred_hr_fft)
                 SNR_all.append(SNR)


### PR DESCRIPTION
Some quick, post-fix results:

[Without smaller sampling window]
FFT MAE (FFT Label): 1.1172537076271187 +/- 0.7542595904048776
FFT RMSE (FFT Label): 5.900322033631117 +/- 33.75286796464523
FFT MAPE (FFT Label): 1.2770134322717948 +/- 0.8337279906070219
FFT Pearson (FFT Label): 0.9689888394596143 +/- 0.03272978926468511
FFT SNR (FFT Label): 8.942749400609268 +/- 0.9383277604051053 (dB)

[With smaller sampling window of 30 seconds]
FFT MAE (FFT Label): 0.7683153973509934 +/- 0.22184007908928535
FFT RMSE (FFT Label): 2.832220802488396 +/- 3.953023632536723
FFT MAPE (FFT Label): 1.0609250742855765 +/- 0.32449846005783045
FFT Pearson (FFT Label): 0.992227258511806 +/- 0.010194440999366668
FFT SNR (FFT Label): 8.8876280935758 +/- 0.6228435207812865 (dB)

[With smaller sampling window of 60 seconds]
FFT MAE (FFT Label): 1.1272927989130435 +/- 0.5379340392718027
FFT RMSE (FFT Label): 5.28139260710191 +/- 22.183051361442022
FFT MAPE (FFT Label): 1.58381447066447 +/- 0.6952154803215566
FFT Pearson (FFT Label): 0.9731489451139645 +/- 0.024262712732727697
FFT SNR (FFT Label): 7.540904400822264 +/- 0.7572398223976812 (dB)