### PR TITLE
PhysFormer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ rPPG-Toolbox currently supports the following algorithms:
   - [EfficientPhys: Enabling Simple, Fast and Accurate Camera-Based Cardiac Measurement (EfficientPhys)](https://openaccess.thecvf.com/content/WACV2023/papers/Liu_EfficientPhys_Enabling_Simple_Fast_and_Accurate_Camera-Based_Cardiac_Measurement_WACV_2023_paper.pdf), by Liu *et al.*, 2023
   - [BigSmall: Efficient Multi-Task Learning for Disparate Spatial and Temporal Physiological Measurements
  (BigSmall)](https://arxiv.org/abs/2303.11573), by Narayanswamy *et al.*, 2023
-
+  - [PhysFormer: Facial Video-based Physiological Measurement with Temporal Difference Transformer (PhysFormer)](https://openaccess.thecvf.com/content/CVPR2022/papers/Yu_PhysFormer_Facial_Video-Based_Physiological_Measurement_With_Temporal_Difference_Transformer_CVPR_2022_paper.pdf), by Yu *et al.*, 2022
 
 # :file_folder: Datasets
 The toolbox supports six datasets, namely SCAMPS, UBFC-rPPG, PURE, BP4D+, UBFC-Phys, and MMPD. Please cite the corresponding papers when using these datasets. For now, we recommend training with UBFC-rPPG, PURE, or SCAMPS due to the level of synchronization and volume of the datasets. **To use these datasets in a deep learning model, you should organize the files as follows.**
@@ -290,7 +290,7 @@ Here are some explanation of parameters:
   * `TASK_LIST`: A list to specify tasks to include when loading a dataset, allowing for selective inclusion of a subset of tasks or a single task in a dataset if desired. This is only used if `SELECT_TASKS` is set to `True`. Currently this parameter is only tested with the [UBFC-Phys](https://sites.google.com/view/ybenezeth/ubfc-phys) dataset. Please refer to one of the config files involving the [UBFC-Phys](https://sites.google.com/view/ybenezeth/ubfc-phys) dataset for an example of using this parameter.
 
   
-* #### MODEL : Set used model (Deepphys, TSCAN, Physnet, EfficientPhys, and BigSmall and their paramaters are supported).
+* #### MODEL : Set used model (Deepphys, TSCAN, Physnet, EfficientPhys, BigSmall, and PhysFormer and their paramaters are supported).
 * #### UNSUPERVISED METHOD: Set used unsupervised method. Example: ["ICA", "POS", "CHROM", "GREEN", "LGI", "PBV"]
 * #### METRICS: Set used metrics. Example: ['MAE','RMSE','MAPE','Pearson']
 * #### INFERENCE:

--- a/config.py
+++ b/config.py
@@ -301,6 +301,17 @@ _C.MODEL.BIGSMALL = CN()
 _C.MODEL.BIGSMALL.FRAME_DEPTH = 3
 
 # -----------------------------------------------------------------------------
+# Model Settings for PhysFormer
+# -----------------------------------------------------------------------------
+_C.MODEL.PHYSFORMER = CN()
+_C.MODEL.PHYSFORMER.PATCH_SIZE = 4
+_C.MODEL.PHYSFORMER.DIM = 96
+_C.MODEL.PHYSFORMER.FF_DIM = 144
+_C.MODEL.PHYSFORMER.NUM_HEADS = 4
+_C.MODEL.PHYSFORMER.NUM_LAYERS = 12
+_C.MODEL.PHYSFORMER.THETA = 0.7
+
+# -----------------------------------------------------------------------------
 # Inference settings
 # -----------------------------------------------------------------------------
 _C.INFERENCE = CN()

--- a/config.py
+++ b/config.py
@@ -485,7 +485,7 @@ def update_config(config, args):
                 model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
                 model_file_name_parts[train_name_idx] = 'MA-' + model_file_name_parts[train_name_idx]
                 config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)
-            if 'Motion' in config.VALID.DATA.PREPROCESS.DATA_AUG and valid_name_part is not None:
+            if 'Motion' in config.VALID.DATA.PREPROCESS.DATA_AUG:
                 model_file_name_parts = config.TRAIN.MODEL_FILE_NAME.split('_')
                 model_file_name_parts[valid_name_idx] = 'MA-' + model_file_name_parts[valid_name_idx]
                 config.TRAIN.MODEL_FILE_NAME = '_'.join(model_file_name_parts)

--- a/configs/infer_configs/PURE_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_MMPD_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,56 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    INFO:
+      LIGHT: [1, 2, 3, 4]  # 1 - LED-Low, 2 - LED-high, 3 - Incandescent, 4 - Nature
+      MOTION: [1, 2, 3, 4] # 1 - Stationary, 2 - Rotation, 3 - Talking, 4 - Walking
+      EXERCISE: [1, 2] # 1 - True, 2 - False
+      SKIN_COLOR: [3, 4, 5, 6] # Fitzpatrick Scale Skin Types - 3, 4, 5, 6
+      GENDER: [1, 2]  # 1 - Male, 2 - Female
+      GLASSER: [1, 2] # 1 - True, 2 - False
+      HAIR_COVER: [1, 2] # 1 - True, 2 - False
+      MAKEUP: [1, 2] # 1 - True, 2 - False
+    FS: 30
+    DATASET: MMPD
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH:   "/your/path/here"          # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"      # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: [ 'DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/PURE_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/PURE_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,61 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                   # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FILTERING:
+      USE_EXCLUSION_LIST: True
+      EXCLUSION_LIST: [
+      's3_T1', 's8_T1', 's9_T1', 's26_T1', 's28_T1', 's30_T1', 's31_T1', 's32_T1',
+      's33_T1', 's40_T1', 's52_T1', 's53_T1', 's54_T1', 's56_T1', 's1_T2', 's4_T2',
+      's6_T2', 's8_T2', 's9_T2', 's11_T2', 's12_T2', 's13_T2', 's14_T2', 's19_T2',
+      's21_T2', 's22_T2', 's25_T2', 's26_T2', 's27_T2', 's28_T2', 's31_T2', 's32_T2',
+      's33_T2', 's35_T2', 's38_T2', 's39_T2', 's41_T2', 's42_T2', 's45_T2', 's47_T2',
+      's48_T2', 's52_T2', 's53_T2', 's55_T2', 's5_T3', 's8_T3', 's9_T3', 's10_T3',
+      's13_T3', 's14_T3', 's17_T3', 's22_T3', 's25_T3', 's26_T3', 's28_T3', 's30_T3',
+      's32_T3', 's33_T3', 's35_T3', 's37_T3', 's40_T3', 's47_T3', 's48_T3', 's49_T3',
+      's50_T3', 's52_T3', 's53_T3']
+      SELECT_TASKS: True
+      TASK_LIST: ['T1', 'T2', 'T3']
+    FS: 35
+    DATASET: UBFC-PHYS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 32
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/PURE_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,47 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/PURE_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,56 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    INFO:
+      LIGHT: [1, 2, 3, 4]  # 1 - LED-Low, 2 - LED-high, 3 - Incandescent, 4 - Nature
+      MOTION: [1, 2, 3, 4] # 1 - Stationary, 2 - Rotation, 3 - Talking, 4 - Walking
+      EXERCISE: [1, 2] # 1 - True, 2 - False
+      SKIN_COLOR: [3, 4, 5, 6] # Fitzpatrick Scale Skin Types - 3, 4, 5, 6
+      GENDER: [1, 2]  # 1 - Male, 2 - Female
+      GLASSER: [1, 2] # 1 - True, 2 - False
+      HAIR_COVER: [1, 2] # 1 - True, 2 - False
+      MAKEUP: [1, 2] # 1 - True, 2 - False
+    FS: 30
+    DATASET: MMPD
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH:   "/your/path/here"          # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"      # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: [ 'DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/SCAMPS_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/SCAMPS_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_PURE_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,47 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/SCAMPS_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,61 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                   # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FILTERING:
+      USE_EXCLUSION_LIST: True
+      EXCLUSION_LIST: [
+      's3_T1', 's8_T1', 's9_T1', 's26_T1', 's28_T1', 's30_T1', 's31_T1', 's32_T1',
+      's33_T1', 's40_T1', 's52_T1', 's53_T1', 's54_T1', 's56_T1', 's1_T2', 's4_T2',
+      's6_T2', 's8_T2', 's9_T2', 's11_T2', 's12_T2', 's13_T2', 's14_T2', 's19_T2',
+      's21_T2', 's22_T2', 's25_T2', 's26_T2', 's27_T2', 's28_T2', 's31_T2', 's32_T2',
+      's33_T2', 's35_T2', 's38_T2', 's39_T2', 's41_T2', 's42_T2', 's45_T2', 's47_T2',
+      's48_T2', 's52_T2', 's53_T2', 's55_T2', 's5_T3', 's8_T3', 's9_T3', 's10_T3',
+      's13_T3', 's14_T3', 's17_T3', 's22_T3', 's25_T3', 's26_T3', 's28_T3', 's30_T3',
+      's32_T3', 's33_T3', 's35_T3', 's37_T3', 's40_T3', 's47_T3', 's48_T3', 's49_T3',
+      's50_T3', 's52_T3', 's53_T3']
+      SELECT_TASKS: True
+      TASK_LIST: ['T1', 'T2', 'T3']
+    FS: 35
+    DATASET: UBFC-PHYS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 32
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/SCAMPS_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,47 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/SCAMPS_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,56 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    INFO:
+      LIGHT: [1, 2, 3, 4]  # 1 - LED-Low, 2 - LED-high, 3 - Incandescent, 4 - Nature
+      MOTION: [1, 2, 3, 4] # 1 - Stationary, 2 - Rotation, 3 - Talking, 4 - Walking
+      EXERCISE: [1, 2] # 1 - True, 2 - False
+      SKIN_COLOR: [3, 4, 5, 6] # Fitzpatrick Scale Skin Types - 3, 4, 5, 6
+      GENDER: [1, 2]  # 1 - Male, 2 - Female
+      GLASSER: [1, 2] # 1 - True, 2 - False
+      HAIR_COVER: [1, 2] # 1 - True, 2 - False
+      MAKEUP: [1, 2] # 1 - True, 2 - False
+    FS: 30
+    DATASET: MMPD
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH:   "/your/path/here"          # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"      # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: [ 'DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/UBFC-rPPG_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,47 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/UBFC-rPPG_PhysFormer_DiffNormalized.pth"

--- a/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,61 @@
+BASE: ['']
+TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                   # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FILTERING:
+      USE_EXCLUSION_LIST: True
+      EXCLUSION_LIST: [
+      's3_T1', 's8_T1', 's9_T1', 's26_T1', 's28_T1', 's30_T1', 's31_T1', 's32_T1',
+      's33_T1', 's40_T1', 's52_T1', 's53_T1', 's54_T1', 's56_T1', 's1_T2', 's4_T2',
+      's6_T2', 's8_T2', 's9_T2', 's11_T2', 's12_T2', 's13_T2', 's14_T2', 's19_T2',
+      's21_T2', 's22_T2', 's25_T2', 's26_T2', 's27_T2', 's28_T2', 's31_T2', 's32_T2',
+      's33_T2', 's35_T2', 's38_T2', 's39_T2', 's41_T2', 's42_T2', 's45_T2', 's47_T2',
+      's48_T2', 's52_T2', 's53_T2', 's55_T2', 's5_T3', 's8_T3', 's9_T3', 's10_T3',
+      's13_T3', 's14_T3', 's17_T3', 's22_T3', 's25_T3', 's26_T3', 's28_T3', 's30_T3',
+      's32_T3', 's33_T3', 's35_T3', 's37_T3', 's40_T3', 's47_T3', 's48_T3', 's49_T3',
+      's50_T3', 's52_T3', 's53_T3']
+      SELECT_TASKS: True
+      TASK_LIST: ['T1', 'T2', 'T3']
+    FS: 35
+    DATASET: UBFC-PHYS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 32
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.2
+  NAME: Tscan
+  TSCAN:
+    FRAME_DEPTH: 10
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 10        # In seconds
+  MODEL_PATH:   "./final_model_release/UBFC-rPPG_PhysFormer_DiffNormalized.pth"

--- a/configs/train_configs/PURE_PURE_MMPD_PHYSFORMER_BASIC .yaml
+++ b/configs/train_configs/PURE_PURE_MMPD_PHYSFORMER_BASIC .yaml
@@ -1,0 +1,121 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: PURE_PURE_MMPD_physformer
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 0.8
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.8
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    INFO:
+      LIGHT: [1, 2, 3, 4]  # 1 - LED-Low, 2 - LED-high, 3 - Incandescent, 4 - Nature
+      MOTION: [1, 2, 3, 4] # 1 - Stationary, 2 - Rotation, 3 - Talking, 4 - Walking
+      EXERCISE: [1, 2] # 1 - True, 2 - False
+      SKIN_COLOR: [3, 4, 5, 6] # Fitzpatrick Scale Skin Types - 3, 4, 5, 6
+      GENDER: [1, 2]  # 1 - Male, 2 - Female
+      GLASSER: [1, 2] # 1 - True, 2 - False
+      HAIR_COVER: [1, 2] # 1 - True, 2 - False
+      MAKEUP: [1, 2] # 1 - True, 2 - False
+    FS: 30
+    DATASET: MMPD
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH:   "/your/path/here"          # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"      # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: [ 'DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/PURE_PURE_UBFC-PHYS_PHYSFORMER_BASIC .yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-PHYS_PHYSFORMER_BASIC .yaml
@@ -1,0 +1,126 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: PURE_PURE_UBFC-PHYS_physformer
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 0.8
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.8
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                   # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FILTERING:
+      USE_EXCLUSION_LIST: True
+      EXCLUSION_LIST: [
+      's3_T1', 's8_T1', 's9_T1', 's26_T1', 's28_T1', 's30_T1', 's31_T1', 's32_T1',
+      's33_T1', 's40_T1', 's52_T1', 's53_T1', 's54_T1', 's56_T1', 's1_T2', 's4_T2',
+      's6_T2', 's8_T2', 's9_T2', 's11_T2', 's12_T2', 's13_T2', 's14_T2', 's19_T2',
+      's21_T2', 's22_T2', 's25_T2', 's26_T2', 's27_T2', 's28_T2', 's31_T2', 's32_T2',
+      's33_T2', 's35_T2', 's38_T2', 's39_T2', 's41_T2', 's42_T2', 's45_T2', 's47_T2',
+      's48_T2', 's52_T2', 's53_T2', 's55_T2', 's5_T3', 's8_T3', 's9_T3', 's10_T3',
+      's13_T3', 's14_T3', 's17_T3', 's22_T3', 's25_T3', 's26_T3', 's28_T3', 's30_T3',
+      's32_T3', 's33_T3', 's35_T3', 's37_T3', 's40_T3', 's47_T3', 's48_T3', 's49_T3',
+      's50_T3', 's52_T3', 's53_T3']
+      SELECT_TASKS: True
+      TASK_LIST: ['T1', 'T2', 'T3']
+    FS: 35
+    DATASET: UBFC-PHYS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 32
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,112 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: PURE_PURE_UBFC-rPPG_physformer
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 0.8
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.8
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/SCAMPS_SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,121 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: SCAMPS_SCAMPS_MMPD_physformer
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/train/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/train/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/val/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/val/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    INFO:
+      LIGHT: [1, 2, 3, 4]  # 1 - LED-Low, 2 - LED-high, 3 - Incandescent, 4 - Nature
+      MOTION: [1, 2, 3, 4] # 1 - Stationary, 2 - Rotation, 3 - Talking, 4 - Walking
+      EXERCISE: [1, 2] # 1 - True, 2 - False
+      SKIN_COLOR: [3, 4, 5, 6] # Fitzpatrick Scale Skin Types - 3, 4, 5, 6
+      GENDER: [1, 2]  # 1 - Male, 2 - Female
+      GLASSER: [1, 2] # 1 - True, 2 - False
+      HAIR_COVER: [1, 2] # 1 - True, 2 - False
+      MAKEUP: [1, 2] # 1 - True, 2 - False
+    FS: 30
+    DATASET: MMPD
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH:   "/your/path/here"          # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"      # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: [ 'DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/SCAMPS_SCAMPS_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_PURE_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,112 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: SCAMPS_SCAMPS_PURE_physformer
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/train/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/train/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/val/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/val/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,126 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: SCAMPS_SCAMPS_UBFC-PHYS_physformer
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/train/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/train/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/val/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/val/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                   # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FILTERING:
+      USE_EXCLUSION_LIST: True
+      EXCLUSION_LIST: [
+      's3_T1', 's8_T1', 's9_T1', 's26_T1', 's28_T1', 's30_T1', 's31_T1', 's32_T1',
+      's33_T1', 's40_T1', 's52_T1', 's53_T1', 's54_T1', 's56_T1', 's1_T2', 's4_T2',
+      's6_T2', 's8_T2', 's9_T2', 's11_T2', 's12_T2', 's13_T2', 's14_T2', 's19_T2',
+      's21_T2', 's22_T2', 's25_T2', 's26_T2', 's27_T2', 's28_T2', 's31_T2', 's32_T2',
+      's33_T2', 's35_T2', 's38_T2', 's39_T2', 's41_T2', 's42_T2', 's45_T2', 's47_T2',
+      's48_T2', 's52_T2', 's53_T2', 's55_T2', 's5_T3', 's8_T3', 's9_T3', 's10_T3',
+      's13_T3', 's14_T3', 's17_T3', 's22_T3', 's25_T3', 's26_T3', 's28_T3', 's30_T3',
+      's32_T3', 's33_T3', 's35_T3', 's37_T3', 's40_T3', 's47_T3', 's48_T3', 's49_T3',
+      's50_T3', 's52_T3', 's53_T3']
+      SELECT_TASKS: True
+      TASK_LIST: ['T1', 'T2', 'T3']
+    FS: 35
+    DATASET: UBFC-PHYS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 32
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,112 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: SCAMPS_SCAMPS_UBFC-rPPG_physformer
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/train/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/train/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: SCAMPS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/val/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/val/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,121 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: UBFC-rPPG_UBFC-rPPG_MMPD_physformer
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 0.8
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.8
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    INFO:
+      LIGHT: [1, 2, 3, 4]  # 1 - LED-Low, 2 - LED-high, 3 - Incandescent, 4 - Nature
+      MOTION: [1, 2, 3, 4] # 1 - Stationary, 2 - Rotation, 3 - Talking, 4 - Walking
+      EXERCISE: [1, 2] # 1 - True, 2 - False
+      SKIN_COLOR: [3, 4, 5, 6] # Fitzpatrick Scale Skin Types - 3, 4, 5, 6
+      GENDER: [1, 2]  # 1 - Male, 2 - Female
+      GLASSER: [1, 2] # 1 - True, 2 - False
+      HAIR_COVER: [1, 2] # 1 - True, 2 - False
+      MAKEUP: [1, 2] # 1 - True, 2 - False
+    FS: 30
+    DATASET: MMPD
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH:   "/your/path/here"          # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"      # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: [ 'DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,112 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: UBFC-rPPG_UBFC-rPPG_PURE_physformer
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 0.8
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.8
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                     # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FS: 30
+    DATASET: PURE
+    DO_PREPROCESS: False                    # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -1,0 +1,126 @@
+BASE: ['']
+TOOLBOX_MODE: "train_and_test"      # "train_and_test"  or "only_test"
+TRAIN:
+  BATCH_SIZE: 4
+  EPOCHS: 10
+  LR: 1e-4
+  MODEL_FILE_NAME: UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_physformer
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False               # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 0.8
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+VALID:
+  DATA:
+    FS: 30
+    DATASET: UBFC-rPPG
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.8
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 30
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+TEST:
+  METRICS: ['MAE','RMSE','MAPE','Pearson', 'SNR']
+  USE_LAST_EPOCH: False                   # to use provided validation dataset to find the best epoch, should be false
+  DATA:
+    FILTERING:
+      USE_EXCLUSION_LIST: True
+      EXCLUSION_LIST: [
+      's3_T1', 's8_T1', 's9_T1', 's26_T1', 's28_T1', 's30_T1', 's31_T1', 's32_T1',
+      's33_T1', 's40_T1', 's52_T1', 's53_T1', 's54_T1', 's56_T1', 's1_T2', 's4_T2',
+      's6_T2', 's8_T2', 's9_T2', 's11_T2', 's12_T2', 's13_T2', 's14_T2', 's19_T2',
+      's21_T2', 's22_T2', 's25_T2', 's26_T2', 's27_T2', 's28_T2', 's31_T2', 's32_T2',
+      's33_T2', 's35_T2', 's38_T2', 's39_T2', 's41_T2', 's42_T2', 's45_T2', 's47_T2',
+      's48_T2', 's52_T2', 's53_T2', 's55_T2', 's5_T3', 's8_T3', 's9_T3', 's10_T3',
+      's13_T3', 's14_T3', 's17_T3', 's22_T3', 's25_T3', 's26_T3', 's28_T3', 's30_T3',
+      's32_T3', 's33_T3', 's35_T3', 's37_T3', 's40_T3', 's47_T3', 's48_T3', 's49_T3',
+      's50_T3', 's52_T3', 's53_T3']
+      SELECT_TASKS: True
+      TASK_LIST: ['T1', 'T2', 'T3']
+    FS: 35
+    DATASET: UBFC-PHYS
+    DO_PREPROCESS: False                  # if first time, should be true
+    DATA_FORMAT: NCDHW
+    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    EXP_DATA_NAME: ""
+    BEGIN: 0.0
+    END: 1.0
+    PREPROCESS:
+      DATA_TYPE: ['DiffNormalized'] #if use physnet, should be DiffNormalized
+      LABEL_TYPE: DiffNormalized
+      DO_CHUNK: True
+      CHUNK_LENGTH: 160
+      CROP_FACE:
+        DO_CROP_FACE: True
+        USE_LARGE_FACE_BOX: True
+        LARGE_BOX_COEF: 1.5
+        DETECTION:
+          DO_DYNAMIC_DETECTION: False
+          DYNAMIC_DETECTION_FREQUENCY : 32
+          USE_MEDIAN_FACE_BOX: False    # This should be used ONLY if dynamic detection is used
+      RESIZE:
+        H: 128
+        W: 128
+DEVICE: cuda:0
+NUM_OF_GPU_TRAIN: 1
+LOG:
+  PATH: runs/exp
+MODEL:
+  DROP_RATE: 0.1
+  NAME: PhysFormer
+  PHYSFORMER:                     # Probably need to update these in some meaningful way
+    PATCH_SIZE: 4
+    DIM: 96
+    FF_DIM: 144
+    NUM_HEADS: 4
+    NUM_LAYERS: 12
+    THETA: 0.7
+INFERENCE:
+  BATCH_SIZE: 4
+  EVALUATION_METHOD: "FFT"        # "FFT" or "peak detection"
+  EVALUATION_WINDOW:
+    USE_SMALLER_WINDOW: False        # Change this if you'd like an evaluation window smaller than the test video length
+    WINDOW_SIZE: 30        # In seconds
+  MODEL_PATH:   ""

--- a/main.py
+++ b/main.py
@@ -73,6 +73,8 @@ def train_and_test(config, data_loader_dict):
         model_trainer = trainer.DeepPhysTrainer.DeepPhysTrainer(config, data_loader_dict)
     elif config.MODEL.NAME == 'BigSmall':
         model_trainer = trainer.BigSmallTrainer.BigSmallTrainer(config, data_loader_dict)
+    elif config.MODEL.NAME == 'PhysFormer':
+        model_trainer = trainer.PhysFormerTrainer.PhysFormerTrainer(config, data_loader_dict)
     else:
         raise ValueError('Your Model is Not Supported  Yet!')
     model_trainer.train(data_loader_dict)
@@ -91,6 +93,8 @@ def test(config, data_loader_dict):
         model_trainer = trainer.DeepPhysTrainer.DeepPhysTrainer(config, data_loader_dict)
     elif config.MODEL.NAME == 'BigSmall':
         model_trainer = trainer.BigSmallTrainer.BigSmallTrainer(config, data_loader_dict)
+    elif config.MODEL.NAME == 'PhysFormer':
+        model_trainer = trainer.PhysFormerTrainer.PhysFormerTrainer(config, data_loader_dict)
     else:
         raise ValueError('Your Model is Not Supported  Yet!')
     model_trainer.test(data_loader_dict)

--- a/neural_methods/loss/PhysFormerLossComputer.py
+++ b/neural_methods/loss/PhysFormerLossComputer.py
@@ -1,0 +1,120 @@
+'''
+  Adapted from here: https://github.com/ZitongYu/PhysFormer/blob/main/TorchLossComputer.py
+  Modifed based on the HR-CNN here: https://github.com/radimspetlik/hr-cnn
+'''
+import math
+import torch
+from torch.autograd import Variable
+import numpy as np
+import torch.nn.functional as F
+import pdb
+import torch.nn as nn
+
+def normal_sampling(mean, label_k, std):
+    return math.exp(-(label_k-mean)**2/(2*std**2))/(math.sqrt(2*math.pi)*std)
+
+def kl_loss(inputs, labels):
+    # Reshape the labels tensor to match the shape of inputs
+    labels = labels.view(1, -1)
+    
+    # Compute the KL Div Loss
+    criterion = nn.KLDivLoss(reduction='sum')
+    loss = criterion(F.log_softmax(inputs, dim=-1), labels)
+    return loss
+ 
+class TorchLossComputer(object):
+    @staticmethod
+    def compute_complex_absolute_given_k(output, k, N):
+        two_pi_n_over_N = torch.autograd.Variable(2 * math.pi * torch.arange(0, N, dtype=torch.float), requires_grad=True) / N
+        hanning = torch.autograd.Variable(torch.from_numpy(np.hanning(N)).type(torch.FloatTensor), requires_grad=True).view(1, -1)
+
+        k = k.type(torch.FloatTensor).cuda()
+        two_pi_n_over_N = two_pi_n_over_N.cuda()
+        hanning = hanning.cuda()
+            
+        output = output.view(1, -1) * hanning
+        output = output.view(1, 1, -1).type(torch.cuda.FloatTensor)
+        k = k.view(1, -1, 1)
+        two_pi_n_over_N = two_pi_n_over_N.view(1, 1, -1)
+        complex_absolute = torch.sum(output * torch.sin(k * two_pi_n_over_N), dim=-1) ** 2 \
+                            + torch.sum(output * torch.cos(k * two_pi_n_over_N), dim=-1) ** 2
+
+        return complex_absolute
+
+    @staticmethod
+    def complex_absolute(output, Fs, bpm_range=None):
+        output = output.view(1, -1)
+
+        N = output.size()[1]
+
+        unit_per_hz = Fs / N
+        feasible_bpm = bpm_range / 60.0
+        k = feasible_bpm / unit_per_hz
+
+        # only calculate feasible PSD range [0.7,4] Hz
+        complex_absolute = TorchLossComputer.compute_complex_absolute_given_k(output, k, N)
+
+        return (1.0 / complex_absolute.sum()) * complex_absolute	# Analogous Softmax operator      
+        
+    @staticmethod
+    def cross_entropy_power_spectrum_loss(inputs, target, Fs):
+        inputs = inputs.view(1, -1)
+        target = target.view(1, -1)
+        bpm_range = torch.arange(40, 180, dtype=torch.float).cuda()
+
+        complex_absolute = TorchLossComputer.complex_absolute(inputs, Fs, bpm_range)
+
+        whole_max_val, whole_max_idx = complex_absolute.view(-1).max(0)
+        whole_max_idx = whole_max_idx.type(torch.float)
+        
+        return F.cross_entropy(complex_absolute, target.view((1)).type(torch.long)),  torch.abs(target[0] - whole_max_idx)
+
+    @staticmethod
+    def cross_entropy_power_spectrum_focal_loss(inputs, target, Fs, gamma):
+        inputs = inputs.view(1, -1)
+        target = target.view(1, -1)
+        bpm_range = torch.arange(40, 180, dtype=torch.float).cuda()
+
+        complex_absolute = TorchLossComputer.complex_absolute(inputs, Fs, bpm_range)
+
+        whole_max_val, whole_max_idx = complex_absolute.view(-1).max(0)
+        whole_max_idx = whole_max_idx.type(torch.float)
+        
+        #pdb.set_trace()
+        criterion = FocalLoss(gamma=gamma)
+
+        return criterion(complex_absolute, target.view((1)).type(torch.long)),  torch.abs(target[0] - whole_max_idx)
+
+        
+    @staticmethod
+    def cross_entropy_power_spectrum_forward_pred(inputs, Fs):
+        inputs = inputs.view(1, -1)
+        bpm_range = torch.arange(40, 190, dtype=torch.float).cuda()
+
+        complex_absolute = TorchLossComputer.complex_absolute(inputs, Fs, bpm_range)
+
+        whole_max_val, whole_max_idx = complex_absolute.view(-1).max(0)
+        whole_max_idx = whole_max_idx.type(torch.float)
+
+        return whole_max_idx
+    
+    @staticmethod
+    def cross_entropy_power_spectrum_DLDL_softmax2(inputs, target, Fs, std):
+        target_distribution = [normal_sampling(int(target), i, std) for i in range(40, 180)]
+        target_distribution = [i if i > 1e-15 else 1e-15 for i in target_distribution]
+        target_distribution = torch.Tensor(target_distribution).to(torch.device('cuda'))
+        
+        inputs = inputs.view(1, -1)
+        target = target.view(1, -1)
+        
+        bpm_range = torch.arange(40, 180, dtype=torch.float).to(torch.device('cuda'))
+
+        ca = TorchLossComputer.complex_absolute(inputs, Fs, bpm_range)
+        
+        fre_distribution = ca/torch.sum(ca)
+        loss_distribution_kl = kl_loss(fre_distribution, target_distribution)
+        
+        whole_max_val, whole_max_idx = ca.view(-1).max(0)
+        whole_max_idx = whole_max_idx.type(torch.float)
+        return loss_distribution_kl, F.cross_entropy(ca, (target-bpm_range[0]).view(1).type(torch.long)),  torch.abs(target[0]-bpm_range[0]-whole_max_idx)
+        

--- a/neural_methods/model/PhysFormer.py
+++ b/neural_methods/model/PhysFormer.py
@@ -1,0 +1,328 @@
+"""This file is a combination of Physformer.py and transformer_layer.py
+   in the official PhysFormer implementation here:
+   https://github.com/ZitongYu/PhysFormer
+
+   model.py - Model and module class for ViT.
+   They are built to mirror those in the official Jax implementation.
+"""
+
+import numpy as np
+from typing import Optional
+import torch
+from torch import nn
+from torch import Tensor 
+from torch.nn import functional as F
+import math
+
+def as_tuple(x):
+    return x if isinstance(x, tuple) else (x, x)
+
+'''
+Temporal Center-difference based Convolutional layer (3D version)
+theta: control the percentage of original convolution and centeral-difference convolution
+'''
+class CDC_T(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1,
+                 padding=1, dilation=1, groups=1, bias=False, theta=0.6):
+
+        super(CDC_T, self).__init__()
+        self.conv = nn.Conv3d(in_channels, out_channels, kernel_size=kernel_size, stride=stride, padding=padding,
+                              dilation=dilation, groups=groups, bias=bias)
+        self.theta = theta
+
+    def forward(self, x):
+        out_normal = self.conv(x)
+
+        if math.fabs(self.theta - 0.0) < 1e-8:
+            return out_normal
+        else:
+            [C_out, C_in, t, kernel_size, kernel_size] = self.conv.weight.shape
+
+            # only CD works on temporal kernel size>1
+            if self.conv.weight.shape[2] > 1:
+                kernel_diff = self.conv.weight[:, :, 0, :, :].sum(2).sum(2) + self.conv.weight[:, :, 2, :, :].sum(
+                    2).sum(2)
+                kernel_diff = kernel_diff[:, :, None, None, None]
+                out_diff = F.conv3d(input=x, weight=kernel_diff, bias=self.conv.bias, stride=self.conv.stride,
+                                    padding=0, dilation=self.conv.dilation, groups=self.conv.groups)
+                return out_normal - self.theta * out_diff
+
+            else:
+                return out_normal
+
+
+def split_last(x, shape):
+    "split the last dimension to given shape"
+    shape = list(shape)
+    assert shape.count(-1) <= 1
+    if -1 in shape:
+        shape[shape.index(-1)] = int(x.size(-1) / -np.prod(shape))
+    return x.view(*x.size()[:-1], *shape)
+
+
+def merge_last(x, n_dims):
+    "merge the last n_dims to a dimension"
+    s = x.size()
+    assert n_dims > 1 and n_dims < len(s)
+    return x.view(*s[:-n_dims], -1)
+
+class MultiHeadedSelfAttention_TDC_gra_sharp(nn.Module):
+    """Multi-Headed Dot Product Attention with depth-wise Conv3d"""
+    def __init__(self, dim, num_heads, dropout, theta):
+        super().__init__()
+        
+        self.proj_q = nn.Sequential(
+            CDC_T(dim, dim, 3, stride=1, padding=1, groups=1, bias=False, theta=theta),  
+            nn.BatchNorm3d(dim),
+            #nn.ELU(),
+        )
+        self.proj_k = nn.Sequential(
+            CDC_T(dim, dim, 3, stride=1, padding=1, groups=1, bias=False, theta=theta),  
+            nn.BatchNorm3d(dim),
+            #nn.ELU(),
+        )
+        self.proj_v = nn.Sequential(
+            nn.Conv3d(dim, dim, 1, stride=1, padding=0, groups=1, bias=False),  
+            #nn.BatchNorm3d(dim),
+            #nn.ELU(),
+        )
+        
+        #self.proj_q = nn.Linear(dim, dim)
+        #self.proj_k = nn.Linear(dim, dim)
+        #self.proj_v = nn.Linear(dim, dim)
+        
+        self.drop = nn.Dropout(dropout)
+        self.n_heads = num_heads
+        self.scores = None # for visualization
+
+    def forward(self, x, gra_sharp):    # [B, 4*4*40, 128]
+        """
+        x, q(query), k(key), v(value) : (B(batch_size), S(seq_len), D(dim))
+        mask : (B(batch_size) x S(seq_len))
+        * split D(dim) into (H(n_heads), W(width of head)) ; D = H * W
+        """
+        # (B, S, D) -proj-> (B, S, D) -split-> (B, S, H, W) -trans-> (B, H, S, W)
+        
+        [B, P, C]=x.shape
+        x = x.transpose(1, 2).view(B, C, P//16, 4, 4)      # [B, dim, 40, 4, 4]
+        q, k, v = self.proj_q(x), self.proj_k(x), self.proj_v(x)
+        q = q.flatten(2).transpose(1, 2)  # [B, 4*4*40, dim]
+        k = k.flatten(2).transpose(1, 2)  # [B, 4*4*40, dim]
+        v = v.flatten(2).transpose(1, 2)  # [B, 4*4*40, dim]
+        
+        q, k, v = (split_last(x, (self.n_heads, -1)).transpose(1, 2) for x in [q, k, v])
+        # (B, H, S, W) @ (B, H, W, S) -> (B, H, S, S) -softmax-> (B, H, S, S)
+        scores = q @ k.transpose(-2, -1) / gra_sharp
+
+        scores = self.drop(F.softmax(scores, dim=-1))
+        # (B, H, S, S) @ (B, H, S, W) -> (B, H, S, W) -trans-> (B, S, H, W)
+        h = (scores @ v).transpose(1, 2).contiguous()
+        # -merge-> (B, S, D)
+        h = merge_last(h, 2)
+        self.scores = scores
+        return h, scores
+
+
+
+
+class PositionWiseFeedForward_ST(nn.Module):
+    """FeedForward Neural Networks for each position"""
+    def __init__(self, dim, ff_dim):
+        super().__init__()
+        
+        self.fc1 = nn.Sequential(
+            nn.Conv3d(dim, ff_dim, 1, stride=1, padding=0, bias=False),  
+            nn.BatchNorm3d(ff_dim),
+            nn.ELU(),
+        )
+        
+        self.STConv = nn.Sequential(
+            nn.Conv3d(ff_dim, ff_dim, 3, stride=1, padding=1, groups=ff_dim, bias=False),  
+            nn.BatchNorm3d(ff_dim),
+            nn.ELU(),
+        )
+        
+        self.fc2 = nn.Sequential(
+            nn.Conv3d(ff_dim, dim, 1, stride=1, padding=0, bias=False),  
+            nn.BatchNorm3d(dim),
+        )
+
+    def forward(self, x):    # [B, 4*4*40, 128]
+        [B, P, C]=x.shape
+        #x = x.transpose(1, 2).view(B, C, 40, 4, 4)      # [B, dim, 40, 4, 4]
+        x = x.transpose(1, 2).view(B, C, P//16, 4, 4)      # [B, dim, 40, 4, 4]
+        x = self.fc1(x)		              # x [B, ff_dim, 40, 4, 4]
+        x = self.STConv(x)		          # x [B, ff_dim, 40, 4, 4]
+        x = self.fc2(x)		              # x [B, dim, 40, 4, 4]
+        x = x.flatten(2).transpose(1, 2)  # [B, 4*4*40, dim]
+        
+        return x
+        
+        # (B, S, D) -> (B, S, D_ff) -> (B, S, D)
+        #return self.fc2(F.gelu(self.fc1(x)))
+
+class Block_ST_TDC_gra_sharp(nn.Module):
+    """Transformer Block"""
+    def __init__(self, dim, num_heads, ff_dim, dropout, theta):
+        super().__init__()
+        self.attn = MultiHeadedSelfAttention_TDC_gra_sharp(dim, num_heads, dropout, theta)
+        self.proj = nn.Linear(dim, dim)
+        self.norm1 = nn.LayerNorm(dim, eps=1e-6)
+        self.pwff = PositionWiseFeedForward_ST(dim, ff_dim)
+        self.norm2 = nn.LayerNorm(dim, eps=1e-6)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x, gra_sharp):
+        Atten, Score = self.attn(self.norm1(x), gra_sharp)
+        h = self.drop(self.proj(Atten))
+        x = x + h
+        h = self.drop(self.pwff(self.norm2(x)))
+        x = x + h
+        return x, Score
+
+class Transformer_ST_TDC_gra_sharp(nn.Module):
+    """Transformer with Self-Attentive Blocks"""
+    def __init__(self, num_layers, dim, num_heads, ff_dim, dropout, theta):
+        super().__init__()
+        self.blocks = nn.ModuleList([
+            Block_ST_TDC_gra_sharp(dim, num_heads, ff_dim, dropout, theta) for _ in range(num_layers)])
+
+    def forward(self, x, gra_sharp):
+        for block in self.blocks:
+            x, Score = block(x, gra_sharp)
+        return x, Score
+
+# stem_3DCNN + ST-ViT with local Depthwise Spatio-Temporal MLP
+class ViT_ST_ST_Compact3_TDC_gra_sharp(nn.Module):
+
+    def __init__(
+        self, 
+        name: Optional[str] = None, 
+        pretrained: bool = False, 
+        patches: int = 16,
+        dim: int = 768,
+        ff_dim: int = 3072,
+        num_heads: int = 12,
+        num_layers: int = 12,
+        attention_dropout_rate: float = 0.0,
+        dropout_rate: float = 0.2,
+        representation_size: Optional[int] = None,
+        load_repr_layer: bool = False,
+        classifier: str = 'token',
+        #positional_embedding: str = '1d',
+        in_channels: int = 3, 
+        frame: int = 160,
+        theta: float = 0.2,
+        image_size: Optional[int] = None,
+    ):
+        super().__init__()
+
+        
+        self.image_size = image_size  
+        self.frame = frame  
+        self.dim = dim              
+
+        # Image and patch sizes
+        t, h, w = as_tuple(image_size)  # tube sizes
+        ft, fh, fw = as_tuple(patches)  # patch sizes, ft = 4 ==> 160/4=40
+        gt, gh, gw = t//ft, h // fh, w // fw  # number of patches
+        seq_len = gh * gw * gt
+
+        # Patch embedding    [4x16x16]conv
+        self.patch_embedding = nn.Conv3d(dim, dim, kernel_size=(ft, fh, fw), stride=(ft, fh, fw))
+        
+        # Transformer
+        self.transformer1 = Transformer_ST_TDC_gra_sharp(num_layers=num_layers//3, dim=dim, num_heads=num_heads, 
+                                       ff_dim=ff_dim, dropout=dropout_rate, theta=theta)
+        # Transformer
+        self.transformer2 = Transformer_ST_TDC_gra_sharp(num_layers=num_layers//3, dim=dim, num_heads=num_heads, 
+                                       ff_dim=ff_dim, dropout=dropout_rate, theta=theta)
+        # Transformer
+        self.transformer3 = Transformer_ST_TDC_gra_sharp(num_layers=num_layers//3, dim=dim, num_heads=num_heads, 
+                                       ff_dim=ff_dim, dropout=dropout_rate, theta=theta)
+        
+        
+        
+        self.Stem0 = nn.Sequential(
+            nn.Conv3d(3, dim//4, [1, 5, 5], stride=1, padding=[0,2,2]),
+            nn.BatchNorm3d(dim//4),
+            nn.ReLU(inplace=True),
+            nn.MaxPool3d((1, 2, 2), stride=(1, 2, 2)),
+        )
+        
+        self.Stem1 = nn.Sequential(
+            nn.Conv3d(dim//4, dim//2, [3, 3, 3], stride=1, padding=1),
+            nn.BatchNorm3d(dim//2),
+            nn.ReLU(inplace=True),
+            nn.MaxPool3d((1, 2, 2), stride=(1, 2, 2)),
+        )
+        self.Stem2 = nn.Sequential(
+            nn.Conv3d(dim//2, dim, [3, 3, 3], stride=1, padding=1),
+            nn.BatchNorm3d(dim),
+            nn.ReLU(inplace=True),
+            nn.MaxPool3d((1, 2, 2), stride=(1, 2, 2)),
+        )
+           
+        self.upsample = nn.Sequential(
+            nn.Upsample(scale_factor=(2,1,1)),
+            nn.Conv3d(dim, dim, [3, 1, 1], stride=1, padding=(1,0,0)),   
+            nn.BatchNorm3d(dim),
+            nn.ELU(),
+        )
+        self.upsample2 = nn.Sequential(
+            nn.Upsample(scale_factor=(2,1,1)),
+            nn.Conv3d(dim, dim//2, [3, 1, 1], stride=1, padding=(1,0,0)),   
+            nn.BatchNorm3d(dim//2),
+            nn.ELU(),
+        )
+ 
+        self.ConvBlockLast = nn.Conv1d(dim//2, 1, 1,stride=1, padding=0)
+        
+        
+        # Initialize weights
+        self.init_weights()
+        
+    @torch.no_grad()
+    def init_weights(self):
+        def _init(m):
+            if isinstance(m, nn.Linear):
+                nn.init.xavier_uniform_(m.weight)  # _trunc_normal(m.weight, std=0.02)  # from .initialization import _trunc_normal
+                if hasattr(m, 'bias') and m.bias is not None:
+                    nn.init.normal_(m.bias, std=1e-6)  # nn.init.constant(m.bias, 0)
+        self.apply(_init)
+
+
+    def forward(self, x, gra_sharp):
+
+        # b is batch number, c channels, t frame, fh frame height, and fw frame width
+        b, c, t, fh, fw = x.shape
+        
+        x = self.Stem0(x)
+        x = self.Stem1(x)
+        x = self.Stem2(x)  # [B, 64, 160, 64, 64]
+        
+        x = self.patch_embedding(x)  # [B, 64, 40, 4, 4]
+        x = x.flatten(2).transpose(1, 2)  # [B, 40*4*4, 64]
+        
+        
+        Trans_features, Score1 =  self.transformer1(x, gra_sharp)  # [B, 4*4*40, 64]
+        Trans_features2, Score2 =  self.transformer2(Trans_features, gra_sharp)  # [B, 4*4*40, 64]
+        Trans_features3, Score3 =  self.transformer3(Trans_features2, gra_sharp)  # [B, 4*4*40, 64]
+        
+        
+        # Trans_features3 = self.normLast(Trans_features3)
+        
+        # upsampling heads
+        #features_last = Trans_features3.transpose(1, 2).view(b, self.dim, 40, 4, 4) # [B, 64, 40, 4, 4]
+        features_last = Trans_features3.transpose(1, 2).view(b, self.dim, t//4, 4, 4) # [B, 64, 40, 4, 4]
+        
+        features_last = self.upsample(features_last)		    # x [B, 64, 7*7, 80]
+        features_last = self.upsample2(features_last)		    # x [B, 32, 7*7, 160]
+        
+        features_last = torch.mean(features_last,3)     # x [B, 32, 160, 4]  
+        features_last = torch.mean(features_last,3)     # x [B, 32, 160]    
+        rPPG = self.ConvBlockLast(features_last)    # x [B, 1, 160]
+        
+        rPPG = rPPG.squeeze(1)
+        
+        return rPPG, Score1, Score2, Score3

--- a/neural_methods/model/PhysFormer.py
+++ b/neural_methods/model/PhysFormer.py
@@ -74,22 +74,14 @@ class MultiHeadedSelfAttention_TDC_gra_sharp(nn.Module):
         self.proj_q = nn.Sequential(
             CDC_T(dim, dim, 3, stride=1, padding=1, groups=1, bias=False, theta=theta),  
             nn.BatchNorm3d(dim),
-            #nn.ELU(),
         )
         self.proj_k = nn.Sequential(
             CDC_T(dim, dim, 3, stride=1, padding=1, groups=1, bias=False, theta=theta),  
             nn.BatchNorm3d(dim),
-            #nn.ELU(),
         )
         self.proj_v = nn.Sequential(
-            nn.Conv3d(dim, dim, 1, stride=1, padding=0, groups=1, bias=False),  
-            #nn.BatchNorm3d(dim),
-            #nn.ELU(),
+            nn.Conv3d(dim, dim, 1, stride=1, padding=0, groups=1, bias=False),
         )
-        
-        #self.proj_q = nn.Linear(dim, dim)
-        #self.proj_k = nn.Linear(dim, dim)
-        #self.proj_v = nn.Linear(dim, dim)
         
         self.drop = nn.Dropout(dropout)
         self.n_heads = num_heads
@@ -149,7 +141,6 @@ class PositionWiseFeedForward_ST(nn.Module):
 
     def forward(self, x):    # [B, 4*4*40, 128]
         [B, P, C]=x.shape
-        #x = x.transpose(1, 2).view(B, C, 40, 4, 4)      # [B, dim, 40, 4, 4]
         x = x.transpose(1, 2).view(B, C, P//16, 4, 4)      # [B, dim, 40, 4, 4]
         x = self.fc1(x)		              # x [B, ff_dim, 40, 4, 4]
         x = self.STConv(x)		          # x [B, ff_dim, 40, 4, 4]
@@ -157,9 +148,6 @@ class PositionWiseFeedForward_ST(nn.Module):
         x = x.flatten(2).transpose(1, 2)  # [B, 4*4*40, dim]
         
         return x
-        
-        # (B, S, D) -> (B, S, D_ff) -> (B, S, D)
-        #return self.fc2(F.gelu(self.fc1(x)))
 
 class Block_ST_TDC_gra_sharp(nn.Module):
     """Transformer Block"""
@@ -308,9 +296,6 @@ class ViT_ST_ST_Compact3_TDC_gra_sharp(nn.Module):
         Trans_features, Score1 =  self.transformer1(x, gra_sharp)  # [B, 4*4*40, 64]
         Trans_features2, Score2 =  self.transformer2(Trans_features, gra_sharp)  # [B, 4*4*40, 64]
         Trans_features3, Score3 =  self.transformer3(Trans_features2, gra_sharp)  # [B, 4*4*40, 64]
-        
-        
-        # Trans_features3 = self.normLast(Trans_features3)
         
         # upsampling heads
         #features_last = Trans_features3.transpose(1, 2).view(b, self.dim, 40, 4, 4) # [B, 64, 40, 4, 4]

--- a/neural_methods/trainer/PhysFormerTrainer.py
+++ b/neural_methods/trainer/PhysFormerTrainer.py
@@ -1,0 +1,252 @@
+"""Trainer for Physformer.
+
+Based on open-source code from the original PhysFormer authors below:
+https://github.com/ZitongYu/PhysFormer/blob/main/train_Physformer_160_VIPL.py
+
+We also thank the PhysBench authors for their open-source code based on the code
+of the original authors. Their code below provided a better reference for tuning loss
+parameters of interest and utilizing RSME as a validation loss:
+https://github.com/KegangWangCCNU/PhysBench/blob/main/benchmark_addition/PhysFormer_pure.ipynb
+
+"""
+
+import os
+import numpy as np
+import math
+import torch
+import torch.optim as optim
+from evaluation.metrics import calculate_metrics
+from neural_methods.loss.PhysNetNegPearsonLoss import Neg_Pearson
+from neural_methods.loss.PhysFormerLossComputer import TorchLossComputer
+from neural_methods.model.PhysFormer import ViT_ST_ST_Compact3_TDC_gra_sharp
+from neural_methods.trainer.BaseTrainer import BaseTrainer
+from tqdm import tqdm
+from scipy.signal import welch
+
+class PhysFormerTrainer(BaseTrainer):
+
+    def __init__(self, config, data_loader):
+        """Inits parameters from args and the writer for TensorboardX."""
+        super().__init__()
+        self.device = torch.device(config.DEVICE)
+        self.max_epoch_num = config.TRAIN.EPOCHS
+        self.model_dir = config.MODEL.MODEL_DIR
+        self.dropout_rate = config.MODEL.DROP_RATE
+        self.patch_size = config.MODEL.PHYSFORMER.PATCH_SIZE
+        self.dim = config.MODEL.PHYSFORMER.DIM
+        self.ff_dim = config.MODEL.PHYSFORMER.FF_DIM
+        self.num_heads = config.MODEL.PHYSFORMER.NUM_HEADS
+        self.num_layers = config.MODEL.PHYSFORMER.NUM_LAYERS
+        self.theta = config.MODEL.PHYSFORMER.THETA
+        self.model_file_name = config.TRAIN.MODEL_FILE_NAME
+        self.batch_size = config.TRAIN.BATCH_SIZE
+        self.num_of_gpu = config.NUM_OF_GPU_TRAIN
+        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
+        self.frame_rate = config.TRAIN.DATA.FS
+        self.config = config 
+        self.min_valid_loss = None
+        self.best_epoch = 0
+
+        if config.TOOLBOX_MODE == "train_and_test":
+            self.model = ViT_ST_ST_Compact3_TDC_gra_sharp(
+                image_size=(self.chunk_len,config.TRAIN.DATA.PREPROCESS.RESIZE.H,config.TRAIN.DATA.PREPROCESS.RESIZE.W), 
+                patches=(self.patch_size,) * 3, dim=self.dim, ff_dim=self.ff_dim, num_heads=self.num_heads, num_layers=self.num_layers, 
+                dropout_rate=self.dropout_rate, theta=self.theta).to(self.device)
+            self.model = torch.nn.DataParallel(self.model, device_ids=list(range(config.NUM_OF_GPU_TRAIN)))
+
+            self.num_train_batches = len(data_loader["train"])
+            self.criterion_reg = torch.nn.MSELoss()
+            self.criterion_L1loss = torch.nn.L1Loss()
+            self.criterion_class = torch.nn.CrossEntropyLoss()
+            self.criterion_Pearson = Neg_Pearson()
+            self.optimizer = optim.Adam(self.model.parameters(), lr=config.TRAIN.LR, weight_decay=0.00005)
+            # TODO: In both the PhysFormer repo's training example and other implementations of a PhysFormer trainer, 
+            # a step_size that doesn't end up changing the LR always seems to be used. This seems to defeat the point
+            # of using StepLR in the first place. Consider investigating and using another approach (e.g., OneCycleLR).
+            self.scheduler = optim.lr_scheduler.StepLR(self.optimizer, step_size=50, gamma=0.5)
+        elif config.TOOLBOX_MODE == "only_test":
+            self.model = ViT_ST_ST_Compact3_TDC_gra_sharp(
+                image_size=(self.chunk_len,config.TRAIN.DATA.PREPROCESS.RESIZE.H,config.TRAIN.DATA.PREPROCESS.RESIZE.W), 
+                patches=(self.patch_size,) * 3, dim=self.dim, ff_dim=self.ff_dim, num_heads=self.num_heads, num_layers=self.num_layers, 
+                dropout_rate=self.dropout_rate, theta=self.theta).to(self.device)
+            self.model = torch.nn.DataParallel(self.model, device_ids=list(range(config.NUM_OF_GPU_TRAIN)))
+        else:
+            raise ValueError("Physformer trainer initialized in incorrect toolbox mode!")
+
+
+    def train(self, data_loader):
+        """Training routine for model"""
+        if data_loader["train"] is None:
+            raise ValueError("No data for train")
+
+        # a --> Pearson loss; b --> frequency loss
+        a_start = 1.0
+        b_start = 1.0
+        exp_a = 0.5     # Unused
+        exp_b = 1.0
+
+        for epoch in range(self.max_epoch_num):
+            print('')
+            print(f"====Training Epoch: {epoch}====")
+            loss_rPPG_avg = []
+            loss_peak_avg = []
+            loss_kl_avg_test = []
+            loss_hr_mae = []
+
+            self.model.train()
+            tbar = tqdm(data_loader["train"], ncols=80)
+            for idx, batch in enumerate(tbar):
+                hr = torch.tensor([self.get_hr(i) for i in batch[1]]).float().to(self.device)
+                data, label = batch[0].float().to(self.device), batch[1].float().to(self.device)
+
+                self.optimizer.zero_grad()
+
+                gra_sharp = 2.0
+                rPPG, _, _, _ = self.model(data, gra_sharp)
+                rPPG = (rPPG-torch.mean(rPPG, axis=-1).view(-1, 1))/torch.std(rPPG, axis=-1).view(-1, 1)    # normalize
+                loss_rPPG = self.criterion_Pearson(rPPG, label)
+
+                fre_loss = 0.0
+                kl_loss = 0.0
+                train_mae = 0.0
+                for bb in range(data.shape[0]):
+                    loss_distribution_kl, \
+                    fre_loss_temp, \
+                    train_mae_temp = TorchLossComputer.cross_entropy_power_spectrum_DLDL_softmax2(
+                        rPPG[bb],
+                        hr[bb],
+                        self.frame_rate,
+                        std=1.0
+                    )
+                    fre_loss = fre_loss+fre_loss_temp
+                    kl_loss = kl_loss+loss_distribution_kl
+                    train_mae = train_mae+train_mae_temp
+                fre_loss /= data.shape[0]
+                kl_loss /= data.shape[0]
+                train_mae /= data.shape[0]
+
+                if epoch>10:
+                    a = 0.05
+                    b = 5.0
+                else:
+                    a = a_start
+                    # exp ascend
+                    b = b_start*math.pow(exp_b, epoch/10.0)
+
+                loss = a*loss_rPPG + b*(fre_loss+kl_loss)
+                loss.backward()
+                self.optimizer.step()
+
+                n = data.size(0)
+                loss_rPPG_avg.append(float(loss_rPPG.data))
+                loss_peak_avg.append(float(fre_loss.data))
+                loss_kl_avg_test.append(float(kl_loss.data))
+                loss_hr_mae.append(float(train_mae))
+                if idx % 100 == 99:  # print every 100 mini-batches
+                    print(f'\nepoch:{epoch}, batch:{idx + 1}, total:{len(data_loader["train"]) // self.batch_size}, '
+                        f'lr:0.0001, sharp:{gra_sharp:.3f}, a:{a:.3f}, NegPearson:{np.mean(loss_rPPG_avg[-2000:]):.4f}, '
+                        f'\nb:{b:.3f}, kl:{np.mean(loss_kl_avg_test[-2000:]):.3f}, fre_CEloss:{np.mean(loss_peak_avg[-2000:]):.3f}, '
+                        f'hr_mae:{np.mean(loss_hr_mae[-2000:]):.3f}')
+            self.save_model(epoch)
+            self.scheduler.step()
+            self.model.eval()
+
+            if not self.config.TEST.USE_LAST_EPOCH: 
+                valid_loss = self.valid(data_loader)
+                print(f'Validation RMSE:{valid_loss:.3f}, batch:{idx+1}')
+                if self.min_valid_loss is None:
+                    self.min_valid_loss = valid_loss
+                    self.best_epoch = epoch
+                    print("Update best model! Best epoch: {}".format(self.best_epoch))
+                elif (valid_loss < self.min_valid_loss):
+                    self.min_valid_loss = valid_loss
+                    self.best_epoch = epoch
+                    print("Update best model! Best epoch: {}".format(self.best_epoch))
+        if not self.config.TEST.USE_LAST_EPOCH: 
+            print("best trained epoch: {}, min_val_loss: {}".format(
+                self.best_epoch, self.min_valid_loss))
+
+    def valid(self, data_loader):
+        """ Runs the model on valid sets."""
+        if data_loader["valid"] is None:
+            raise ValueError("No data for valid")
+
+        print('')
+        print(" ====Validating===")
+        self.optimizer.zero_grad()
+        with torch.no_grad():
+            hrs = []
+            vbar = tqdm(data_loader["valid"], ncols=80)
+            for val_idx, val_batch in enumerate(vbar):
+                data, label = val_batch[0].float().to(self.device), val_batch[1].float().to(self.device)
+                gra_sharp = 2.0
+                rPPG, _, _, _ = self.model(data, gra_sharp)
+                rPPG = (rPPG-torch.mean(rPPG, axis=-1).view(-1, 1))/torch.std(rPPG).view(-1, 1)
+                for _1, _2 in zip(rPPG, label):
+                    hrs.append((self.get_hr(_1.cpu().detach().numpy()), self.get_hr(_2.cpu().detach().numpy())))
+            RMSE = np.mean([(i-j)**2 for i, j in hrs])**0.5
+        return RMSE
+
+    def test(self, data_loader):
+        """ Runs the model on test sets."""
+        if data_loader["test"] is None:
+            raise ValueError("No data for test")
+        
+        print('')
+        print("===Testing===")
+        predictions = dict()
+        labels = dict()
+
+        if self.config.TOOLBOX_MODE == "only_test":
+            if not os.path.exists(self.config.INFERENCE.MODEL_PATH):
+                raise ValueError("Inference model path error! Please check INFERENCE.MODEL_PATH in your yaml.")
+            self.model.load_state_dict(torch.load(self.config.INFERENCE.MODEL_PATH))
+            print("Testing uses pretrained model!")
+            print(self.config.INFERENCE.MODEL_PATH)
+        else:
+            if self.config.TEST.USE_LAST_EPOCH:
+                last_epoch_model_path = os.path.join(
+                self.model_dir, self.model_file_name + '_Epoch' + str(self.max_epoch_num - 1) + '.pth')
+                print("Testing uses last epoch as non-pretrained model!")
+                print(last_epoch_model_path)
+                self.model.load_state_dict(torch.load(last_epoch_model_path))
+            else:
+                best_model_path = os.path.join(
+                    self.model_dir, self.model_file_name + '_Epoch' + str(self.best_epoch) + '.pth')
+                print("Testing uses best epoch selected using model selection as non-pretrained model!")
+                print(best_model_path)
+                self.model.load_state_dict(torch.load(best_model_path))
+
+        self.model = self.model.to(self.config.DEVICE)
+        self.model.eval()
+        with torch.no_grad():
+            for _, test_batch in enumerate(data_loader['test']):
+                batch_size = test_batch[0].shape[0]
+                data, label = test_batch[0].to(
+                    self.config.DEVICE), test_batch[1].to(self.config.DEVICE)
+                gra_sharp = 2.0
+                pred_ppg_test, _, _, _ = self.model(data, gra_sharp)
+                for idx in range(batch_size):
+                    subj_index = test_batch[2][idx]
+                    sort_index = int(test_batch[3][idx])
+                    if subj_index not in predictions.keys():
+                        predictions[subj_index] = dict()
+                        labels[subj_index] = dict()
+                    predictions[subj_index][sort_index] = pred_ppg_test[idx]
+                    labels[subj_index][sort_index] = label[idx]
+
+        print('')
+        calculate_metrics(predictions, labels, self.config)
+
+    def save_model(self, index):
+        if not os.path.exists(self.model_dir):
+            os.makedirs(self.model_dir)
+        model_path = os.path.join(
+            self.model_dir, self.model_file_name + '_Epoch' + str(index) + '.pth')
+        torch.save(self.model.state_dict(), model_path)
+        print('Saved Model Path: ', model_path)
+
+    # HR calculation based on ground truth label
+    def get_hr(self, y, sr=30, min=30, max=180):
+        p, q = welch(y, sr, nfft=1e5/sr, nperseg=np.min((len(y)-1, 256)))
+        return p[(p>min/60)&(p<max/60)][np.argmax(q[(p>min/60)&(p<max/60)])]*60

--- a/neural_methods/trainer/__init__.py
+++ b/neural_methods/trainer/__init__.py
@@ -4,3 +4,4 @@ import neural_methods.trainer.TscanTrainer
 import neural_methods.trainer.DeepPhysTrainer
 import neural_methods.trainer.EfficientPhysTrainer
 import neural_methods.trainer.BigSmallTrainer
+import neural_methods.trainer.PhysFormerTrainer


### PR DESCRIPTION
This PR revolves around PhysFormer model support, including train configs, infer configs, and pre-trained models that were used for results in a pending update to the pre-print associated with the rPPG-Toolbox. Please see the individual commits for more details.