### PR TITLE
Face Detection Backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Here are some explanation of parameters:
   * `DO_CHUNK`: Whether to split the raw data into smaller chunks
   * `CHUNK_LENGTH`: The length of each chunk (number of frames)
   * `DO_CROP_FACE`: Whether to perform face detection
+  * `BACKEND`: Select which backend to use for face detection. Currently, the options are HC (Haar Cascade) or RF (RetinaFace). We recommend using Haar Cascade (the config default) in order to reproduce results from the [NeurIPS 2023 Datasets and Benchmarks paper](https://arxiv.org/abs/2210.00716) that corresponds to this toolbox. If you use RetinaFace, we recommend that you experiment with parameters such as `LARGE_BOX_COEF` and `USE_MEDIAN_BOX` depending on what dataset you are preprocessnig. We plan to update this README with optimal settings to use with RetinaFace in the near future.
   * `DYNAMIC_DETECTION`: If `False`, face detection is only performed at the first frame and the detected box is used to crop the video for all of the subsequent frames. If `True`, face detection is performed at a specific frequency which is defined by `DYNAMIC_DETECTION_FREQUENCY`. 
   * `DYNAMIC_DETECTION_FREQUENCY`: The frequency of face detection (number of frames) if DYNAMIC_DETECTION is `True`
   * `USE_MEDIAN_FACE_BOX`: If `True` and `DYNAMIC_DETECTION` is `True`, use the detected face boxs throughout each video to create a single, median face box per video.

--- a/config.py
+++ b/config.py
@@ -70,6 +70,7 @@ _C.TRAIN.DATA.PREPROCESS.DO_CHUNK = True
 _C.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.TRAIN.DATA.PREPROCESS.CROP_FACE = CN()
 _C.TRAIN.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE = True
+_C.TRAIN.DATA.PREPROCESS.CROP_FACE.BACKEND = 'HC'
 _C.TRAIN.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX = True
 _C.TRAIN.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF = 1.5
 _C.TRAIN.DATA.PREPROCESS.CROP_FACE.DETECTION = CN()
@@ -130,6 +131,7 @@ _C.VALID.DATA.PREPROCESS.DO_CHUNK = True
 _C.VALID.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.VALID.DATA.PREPROCESS.CROP_FACE = CN()
 _C.VALID.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE = True
+_C.VALID.DATA.PREPROCESS.CROP_FACE.BACKEND = 'HC'
 _C.VALID.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX = True
 _C.VALID.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF = 1.5
 _C.VALID.DATA.PREPROCESS.CROP_FACE.DETECTION = CN()
@@ -194,6 +196,7 @@ _C.TEST.DATA.PREPROCESS.DO_CHUNK = True
 _C.TEST.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.TEST.DATA.PREPROCESS.CROP_FACE = CN()
 _C.TEST.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE = True
+_C.TEST.DATA.PREPROCESS.CROP_FACE.BACKEND = 'HC'
 _C.TEST.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX = True
 _C.TEST.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF = 1.5
 _C.TEST.DATA.PREPROCESS.CROP_FACE.DETECTION = CN()
@@ -258,6 +261,7 @@ _C.UNSUPERVISED.DATA.PREPROCESS.DO_CHUNK = True
 _C.UNSUPERVISED.DATA.PREPROCESS.CHUNK_LENGTH = 180
 _C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE = CN()
 _C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE = True
+_C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.BACKEND = 'HC'
 _C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX = True
 _C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF = 1.5
 _C.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.DETECTION = CN()
@@ -375,6 +379,7 @@ def update_config(config, args):
                                       "DataAug{0}".format("_".join(config.TRAIN.DATA.PREPROCESS.DATA_AUG)),
                                       "LabelType{0}".format(config.TRAIN.DATA.PREPROCESS.LABEL_TYPE),
                                       "Crop_face{0}".format(config.TRAIN.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
+                                      "Backend{0}".format(config.TRAIN.DATA.PREPROCESS.CROP_FACE.BACKEND),
                                       "Large_box{0}".format(config.TRAIN.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),
                                       "Large_size{0}".format(config.TRAIN.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF),
                                       "Dyamic_Det{0}".format(config.TRAIN.DATA.PREPROCESS.CROP_FACE.DETECTION.DO_DYNAMIC_DETECTION),
@@ -410,6 +415,7 @@ def update_config(config, args):
                                         "DataAug{0}".format("_".join(config.VALID.DATA.PREPROCESS.DATA_AUG)),
                                         "LabelType{0}".format(config.VALID.DATA.PREPROCESS.LABEL_TYPE),
                                         "Crop_face{0}".format(config.VALID.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
+                                        "Backend{0}".format(config.VALID.DATA.PREPROCESS.CROP_FACE.BACKEND),
                                         "Large_box{0}".format(config.VALID.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),
                                         "Large_size{0}".format(config.VALID.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF),
                                         "Dyamic_Det{0}".format(config.VALID.DATA.PREPROCESS.CROP_FACE.DETECTION.DO_DYNAMIC_DETECTION),
@@ -446,6 +452,7 @@ def update_config(config, args):
                                       "DataAug{0}".format("_".join(config.TEST.DATA.PREPROCESS.DATA_AUG)),
                                       "LabelType{0}".format(config.TEST.DATA.PREPROCESS.LABEL_TYPE),
                                       "Crop_face{0}".format(config.TEST.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
+                                      "Backend{0}".format(config.TEST.DATA.PREPROCESS.CROP_FACE.BACKEND),
                                       "Large_box{0}".format(config.TEST.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),
                                       "Large_size{0}".format(config.TEST.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF),
                                       "Dyamic_Det{0}".format(config.TEST.DATA.PREPROCESS.CROP_FACE.DETECTION.DO_DYNAMIC_DETECTION),
@@ -514,6 +521,7 @@ def update_config(config, args):
                                       "DataAug{0}".format("_".join(config.UNSUPERVISED.DATA.PREPROCESS.DATA_AUG)),
                                       "LabelType{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.LABEL_TYPE),
                                       "Crop_face{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.DO_CROP_FACE),
+                                      "Backend{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.BACKEND),
                                       "Large_box{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.USE_LARGE_FACE_BOX),
                                       "Large_size{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.LARGE_BOX_COEF),
                                       "Dyamic_Det{0}".format(config.UNSUPERVISED.DATA.PREPROCESS.CROP_FACE.DETECTION.DO_DYNAMIC_DETECTION),

--- a/configs/infer_configs/MMPD_UNSUPERVISED.yaml
+++ b/configs/infer_configs/MMPD_UNSUPERVISED.yaml
@@ -29,6 +29,7 @@ UNSUPERVISED:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_MMPD_PHYSFORMER_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_MMPD_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/PURE_MMPD_TSCAN_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-PHYS_DEEPPHYS_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-PHYS_DEEPPHYS_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 210
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-PHYS_EFFICIENTPHYS.yaml
+++ b/configs/infer_configs/PURE_UBFC-PHYS_EFFICIENTPHYS.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 210
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-PHYS_PHYSNET_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-PHYS_PHYSNET_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-PHYS_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-PHYS_TSCAN_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 210
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-rPPG_DEEPPHYS_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_DEEPPHYS_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-rPPG_EFFICIENTPHYS.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_EFFICIENTPHYS.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-rPPG_PHYSNET_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_PHYSNET_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UBFC-rPPG_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_TSCAN_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_UNSUPERVISED.yaml
+++ b/configs/infer_configs/PURE_UNSUPERVISED.yaml
@@ -21,6 +21,7 @@ UNSUPERVISED:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_MMPD_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_MMPD_TSCAN_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_PURE_DEEPPHYS_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_PURE_EFFICIENTPHYS.yaml
+++ b/configs/infer_configs/SCAMPS_PURE_EFFICIENTPHYS.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_PURE_PHYSFORMER_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_PURE_PHYSNET_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_PURE_PHYSNET_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_PURE_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_PURE_TSCAN_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_UBFC-rPPG_DEEPPHYS_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-rPPG_DEEPPHYS_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_UBFC-rPPG_EFFICIENTPHYS.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-rPPG_EFFICIENTPHYS.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_UBFC-rPPG_PHYSNET_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-rPPG_PHYSNET_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/SCAMPS_UBFC-rPPG_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/SCAMPS_UBFC-rPPG_TSCAN_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-PHYS_UNSUPERVISED.yaml
+++ b/configs/infer_configs/UBFC-PHYS_UNSUPERVISED.yaml
@@ -35,6 +35,7 @@ UNSUPERVISED:
       CHUNK_LENGTH: 210
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_MMPD_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_MMPD_TSCAN_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_DEEPPHYS_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_PURE_EFFICIENTPHYS.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_EFFICIENTPHYS.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_PURE_PHYSNET_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_PHYSNET_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_PURE_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_TSCAN_BASIC.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'RF'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_DEEPPHYS_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_DEEPPHYS_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 210
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_EFFICIENTPHYS.yaml
+++ b/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_EFFICIENTPHYS.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 210
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_PHYSNET_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_PHYSNET_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_TSCAN_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_UBFC-PHYS_TSCAN_BASIC.yaml
@@ -34,6 +34,7 @@ TEST:
       CHUNK_LENGTH: 210
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_UNSUPERVISED.yaml
+++ b/configs/infer_configs/UBFC-rPPG_UNSUPERVISED.yaml
@@ -21,6 +21,7 @@ UNSUPERVISED:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/BP4D_BP4D_PURE_DEEPPHYS_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_PURE_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/BP4D_BP4D_PURE_EFFICIENTPHYS.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_PURE_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/BP4D_BP4D_PURE_PHYSNET_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 128
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 128
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 128
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_PURE_TSCAN_BASIC.yaml
+++ b/configs/train_configs/BP4D_BP4D_PURE_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_UBFC-rPPG_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/BP4D_BP4D_UBFC-rPPG_DEEPPHYS_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_UBFC-rPPG_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/BP4D_BP4D_UBFC-rPPG_EFFICIENTPHYS.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_UBFC-rPPG_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/BP4D_BP4D_UBFC-rPPG_PHYSNET_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 128
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 128
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 128
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/BP4D_BP4D_UBFC-rPPG_TSCAN_BASIC.yaml
+++ b/configs/train_configs/BP4D_BP4D_UBFC-rPPG_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/MMPD_MMPD_UBFC-rPPG_TSCAN_BASIC.yaml
+++ b/configs/train_configs/MMPD_MMPD_UBFC-rPPG_TSCAN_BASIC.yaml
@@ -32,6 +32,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -68,6 +69,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -97,6 +99,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_MMPD_PHYSFORMER_BASIC .yaml
+++ b/configs/train_configs/PURE_PURE_MMPD_PHYSFORMER_BASIC .yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -90,6 +92,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_MMPD_TSCAN_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_MMPD_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -51,6 +52,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -89,6 +91,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-PHYS_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-PHYS_DEEPPHYS_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-PHYS_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-PHYS_EFFICIENTPHYS.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-PHYS_PHYSFORMER_BASIC .yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-PHYS_PHYSFORMER_BASIC .yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-PHYS_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-PHYS_PHYSNET_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-PHYS_TSCAN_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-PHYS_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_DEEPPHYS_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_EFFICIENTPHYS.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -11,8 +11,8 @@ TRAIN:
     DATASET: PURE
     DO_PREPROCESS: False               # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
-    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    DATA_PATH: "/playpen-nas-hdd/UNC_Google_Physio/PURE/RawData/test"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/playpen-nas-ssd/akshay/UNC_Google_Physio/preprocessed_gold/train"    # Processed dataset save path, need to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 0.8
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -39,8 +40,8 @@ VALID:
     DATASET: PURE
     DO_PREPROCESS: False                  # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
-    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    DATA_PATH: "/playpen-nas-hdd/UNC_Google_Physio/PURE/RawData/test"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/playpen-nas-ssd/akshay/UNC_Google_Physio/preprocessed_gold/val"    # Processed dataset save path, need to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.8
     END: 1.0
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -69,8 +71,8 @@ TEST:
     DATASET: UBFC-rPPG
     DO_PREPROCESS: False                    # if first time, should be true
     DATA_FORMAT: NCDHW
-    DATA_PATH: "/your/path/here"                     # Raw dataset path, need to be updated
-    CACHED_PATH: "/your/path/here"    # Processed dataset save path, need to be updated
+    DATA_PATH: "/playpen-nas-hdd/UNC_Google_Physio/UBFC-rPPG/DATASET_2_backup/DATASET_2/test"                     # Raw dataset path, need to be updated
+    CACHED_PATH: "/playpen-nas-ssd/akshay/UNC_Google_Physio/preprocessed_gold/test"    # Processed dataset save path, need to be updated
     EXP_DATA_NAME: ""
     BEGIN: 0.0
     END: 1.0
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_PHYSNET_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_TSCAN_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_MMPD_PHYSFORMER_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -90,6 +92,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_MMPD_TSCAN_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_MMPD_TSCAN_BASIC.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -88,6 +90,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_PURE_DEEPPHYS_BASIC.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +81,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_PURE_PHYSFORMER_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_PURE_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_PURE_PHYSNET_BASIC.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +81,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_PURE_TSCAN_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_PURE_TSCAN_BASIC.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +81,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_DEEPPHYS_BASIC.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +81,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_EFFICIENTPHYS.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +81,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_PHYSFORMER_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_PHYSNET_BASIC.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +81,7 @@ TEST:
       CHUNK_LENGTH: 128                 #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_TSCAN_BASIC.yaml
+++ b/configs/train_configs/SCAMPS_SCAMPS_UBFC-rPPG_TSCAN_BASIC.yaml
@@ -23,6 +23,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -50,6 +51,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +81,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_PHYSFORMER_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -90,6 +92,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_TSCAN_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -90,6 +92,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_DEEPPHYS_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_EFFICIENTPHYS.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSFORMER_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSNET_BASIC.yaml
@@ -25,6 +25,7 @@ TRAIN:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -54,6 +55,7 @@ VALID:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -84,6 +86,7 @@ TEST:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_TSCAN_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -81,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_DEEPPHYS_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_DEEPPHYS_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_EFFICIENTPHYS.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_EFFICIENTPHYS.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_PHYSFORMER_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_PHYSNET_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_PHYSNET_BASIC.yaml
@@ -25,6 +25,7 @@ TRAIN:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -54,6 +55,7 @@ VALID:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -98,6 +100,7 @@ TEST:
       CHUNK_LENGTH: 128  #only support for factor of 512
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_TSCAN_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_UBFC-PHYS_TSCAN_BASIC.yaml
@@ -24,6 +24,7 @@ TRAIN:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -52,6 +53,7 @@ VALID:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -95,6 +97,7 @@ TEST:
       CHUNK_LENGTH: 180
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -22,6 +22,7 @@ import numpy as np
 import pandas as pd
 from torch.utils.data import Dataset
 from tqdm import tqdm
+from retinaface import RetinaFace   # Source code: https://github.com/serengil/retinaface
 
 
 class BaseLoader(Dataset):
@@ -224,6 +225,7 @@ class BaseLoader(Dataset):
         frames = self.crop_face_resize(
             frames,
             config_preprocess.CROP_FACE.DO_CROP_FACE,
+            config_preprocess.CROP_FACE.BACKEND,
             config_preprocess.CROP_FACE.USE_LARGE_FACE_BOX,
             config_preprocess.CROP_FACE.LARGE_BOX_COEF,
             config_preprocess.CROP_FACE.DETECTION.DO_DYNAMIC_DETECTION,
@@ -262,34 +264,78 @@ class BaseLoader(Dataset):
 
         return frames_clips, bvps_clips
 
-    def face_detection(self, frame, use_larger_box=False, larger_box_coef=1.0):
+    def face_detection(self, frame, backend, use_larger_box=False, larger_box_coef=1.0):
         """Face detection on a single frame.
 
         Args:
             frame(np.array): a single frame.
+            backend(str): backend to utilize for face detection.
             use_larger_box(bool): whether to use a larger bounding box on face detection.
             larger_box_coef(float): Coef. of larger box.
         Returns:
             face_box_coor(List[int]): coordinates of face bouding box.
         """
+        if backend == "HC":
+            # Use OpenCV's Haar Cascade algorithm implementation for face detection
+            # This should only utilize the CPU
+            detector = cv2.CascadeClassifier(
+            './dataset/haarcascade_frontalface_default.xml')
 
-        detector = cv2.CascadeClassifier(
-           './dataset/haarcascade_frontalface_default.xml')
-        # Computed face_zone(s) are in the form [x_coord, y_coord, width, height]
-        # (x,y) corresponds to the top-left corner of the zone to define using
-        # the computed width and height.
-        face_zone = detector.detectMultiScale(frame)
-        if len(face_zone) < 1:
-            print("ERROR: No Face Detected")
-            face_box_coor = [0, 0, frame.shape[0], frame.shape[1]]
-        elif len(face_zone) >= 2:
-            # Find the index of the largest face zone
-            # The face zones are boxes, so the width and height are the same
-            max_width_index = np.argmax(face_zone[:, 2])  # Index of maximum width
-            face_box_coor = face_zone[max_width_index]
-            print("Warning: More than one faces are detected. Only cropping the biggest one.")
+            # Computed face_zone(s) are in the form [x_coord, y_coord, width, height]
+            # (x,y) corresponds to the top-left corner of the zone to define using
+            # the computed width and height.
+            face_zone = detector.detectMultiScale(frame)
+
+            if len(face_zone) < 1:
+                print("ERROR: No Face Detected")
+                face_box_coor = [0, 0, frame.shape[0], frame.shape[1]]
+            elif len(face_zone) >= 2:
+                # Find the index of the largest face zone
+                # The face zones are boxes, so the width and height are the same
+                max_width_index = np.argmax(face_zone[:, 2])  # Index of maximum width
+                face_box_coor = face_zone[max_width_index]
+                print("Warning: More than one faces are detected. Only cropping the biggest one.")
+            else:
+                face_box_coor = face_zone[0]
+        elif backend == "RF":
+            # Use a TensorFlow-based RetinaFace implementation for face detection
+            # This utilizes both the CPU and GPU
+            res = RetinaFace.detect_faces(frame)
+
+            if len(res) > 0:
+                # Pick the highest score
+                highest_score_face = max(res.values(), key=lambda x: x['score'])
+                face_zone = highest_score_face['facial_area']
+
+                # This implementation of RetinaFace returns a face_zone in the
+                # form [x_min, y_min, x_max, y_max] that corresponds to the 
+                # corners of a face zone
+                x_min, y_min, x_max, y_max = face_zone
+
+                # Convert to this toolbox's expected format
+                # Expected format: [x_coord, y_coord, width, height]
+                x = x_min
+                y = y_min
+                width = x_max - x_min
+                height = y_max - y_min
+
+                # Find the center of the face zone
+                center_x = x + width // 2
+                center_y = y + height // 2
+                
+                # Determine the size of the square (use the maximum of width and height)
+                square_size = max(width, height)
+                
+                # Calculate the new coordinates for a square face zone
+                new_x = center_x - (square_size // 2)
+                new_y = center_y - (square_size // 2)
+                face_box_coor = [new_x, new_y, square_size, square_size]
+            else:
+                print("ERROR: No Face Detected")
+                face_box_coor = [0, 0, frame.shape[0], frame.shape[1]]
         else:
-            face_box_coor = face_zone[0]
+            raise ValueError("Unsupported face detection backend!")
+
         if use_larger_box:
             face_box_coor[0] = max(0, face_box_coor[0] - (larger_box_coef - 1.0) / 2 * face_box_coor[2])
             face_box_coor[1] = max(0, face_box_coor[1] - (larger_box_coef - 1.0) / 2 * face_box_coor[3])
@@ -297,7 +343,7 @@ class BaseLoader(Dataset):
             face_box_coor[3] = larger_box_coef * face_box_coor[3]
         return face_box_coor
 
-    def crop_face_resize(self, frames, use_face_detection, use_larger_box, larger_box_coef, use_dynamic_detection, 
+    def crop_face_resize(self, frames, use_face_detection, backend, use_larger_box, larger_box_coef, use_dynamic_detection, 
                          detection_freq, use_median_box, width, height):
         """Crop face and resize frames.
 
@@ -325,14 +371,13 @@ class BaseLoader(Dataset):
         # Perform face detection by num_dynamic_det" times.
         for idx in range(num_dynamic_det):
             if use_face_detection:
-                face_region_all.append(self.face_detection(frames[detection_freq * idx], use_larger_box, larger_box_coef))
+                face_region_all.append(self.face_detection(frames[detection_freq * idx], backend, use_larger_box, larger_box_coef))
             else:
                 face_region_all.append([0, 0, frames.shape[1], frames.shape[2]])
         face_region_all = np.asarray(face_region_all, dtype='int')
         if use_median_box:
             # Generate a median bounding box based on all detected face regions
             face_region_median = np.median(face_region_all, axis=0).astype('int')
-
 
         # Frame Resizing
         resized_frames = np.zeros((frames.shape[0], height, width, 3))

--- a/dataset/data_loader/BaseLoader.py
+++ b/dataset/data_loader/BaseLoader.py
@@ -275,14 +275,19 @@ class BaseLoader(Dataset):
 
         detector = cv2.CascadeClassifier(
            './dataset/haarcascade_frontalface_default.xml')
+        # Computed face_zone(s) are in the form [x_coord, y_coord, width, height]
+        # (x,y) corresponds to the top-left corner of the zone to define using
+        # the computed width and height.
         face_zone = detector.detectMultiScale(frame)
         if len(face_zone) < 1:
             print("ERROR: No Face Detected")
             face_box_coor = [0, 0, frame.shape[0], frame.shape[1]]
         elif len(face_zone) >= 2:
-            face_box_coor = np.argmax(face_zone, axis=0)
-            face_box_coor = face_zone[face_box_coor[2]]
-            print("Warning: More than one faces are detected(Only cropping the biggest one.)")
+            # Find the index of the largest face zone
+            # The face zones are boxes, so the width and height are the same
+            max_width_index = np.argmax(face_zone[:, 2])  # Index of maximum width
+            face_box_coor = face_zone[max_width_index]
+            print("Warning: More than one faces are detected. Only cropping the biggest one.")
         else:
             face_box_coor = face_zone[0]
         if use_larger_box:

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -49,6 +49,7 @@ def calculate_metrics(predictions, labels, config):
     predict_hr_peak_all = list()
     gt_hr_peak_all = list()
     SNR_all = list()
+    print("Calculating metrics!")
     for index in tqdm(predictions.keys(), ncols=80):
         prediction = _reform_data_from_dict(predictions[index])
         label = _reform_data_from_dict(labels[index])

--- a/neural_methods/trainer/BigSmallTrainer.py
+++ b/neural_methods/trainer/BigSmallTrainer.py
@@ -399,8 +399,9 @@ class BigSmallTrainer(BaseTrainer):
         self.model.eval()
 
         # MODEL TESTING
+        print("Running model evaluation on the testing dataset!")
         with torch.no_grad():
-            for _, test_batch in enumerate(data_loader['test']):
+            for _, test_batch in enumerate(tqdm(data_loader["test"], ncols=80)):
 
                 # PROCESSING - ANALYSIS, METRICS, SAVING OUT DATA
                 batch_size = test_batch[1].shape[0] # get batch size

--- a/neural_methods/trainer/DeepPhysTrainer.py
+++ b/neural_methods/trainer/DeepPhysTrainer.py
@@ -166,8 +166,9 @@ class DeepPhysTrainer(BaseTrainer):
 
         self.model = self.model.to(self.config.DEVICE)
         self.model.eval()
+        print("Running model evaluation on the testing dataset!")
         with torch.no_grad():
-            for _, test_batch in enumerate(data_loader['test']):
+            for _, test_batch in enumerate(tqdm(data_loader["test"], ncols=80)):
                 batch_size = test_batch[0].shape[0]
                 data_test, labels_test = test_batch[0].to(
                     self.config.DEVICE), test_batch[1].to(self.config.DEVICE)

--- a/neural_methods/trainer/EfficientPhysTrainer.py
+++ b/neural_methods/trainer/EfficientPhysTrainer.py
@@ -181,8 +181,9 @@ class EfficientPhysTrainer(BaseTrainer):
 
         self.model = self.model.to(self.config.DEVICE)
         self.model.eval()
+        print("Running model evaluation on the testing dataset!")
         with torch.no_grad():
-            for _, test_batch in enumerate(data_loader['test']):
+            for _, test_batch in enumerate(tqdm(data_loader["test"], ncols=80)):
                 batch_size = test_batch[0].shape[0]
                 data_test, labels_test = test_batch[0].to(
                     self.config.DEVICE), test_batch[1].to(self.config.DEVICE)

--- a/neural_methods/trainer/PhysFormerTrainer.py
+++ b/neural_methods/trainer/PhysFormerTrainer.py
@@ -232,8 +232,9 @@ class PhysFormerTrainer(BaseTrainer):
 
         self.model = self.model.to(self.config.DEVICE)
         self.model.eval()
+        print("Running model evaluation on the testing dataset!")
         with torch.no_grad():
-            for _, test_batch in enumerate(data_loader['test']):
+            for _, test_batch in enumerate(tqdm(data_loader["test"], ncols=80)):
                 batch_size = test_batch[0].shape[0]
                 data, label = test_batch[0].to(
                     self.config.DEVICE), test_batch[1].to(self.config.DEVICE)

--- a/neural_methods/trainer/PhysnetTrainer.py
+++ b/neural_methods/trainer/PhysnetTrainer.py
@@ -168,8 +168,9 @@ class PhysnetTrainer(BaseTrainer):
 
         self.model = self.model.to(self.config.DEVICE)
         self.model.eval()
+        print("Running model evaluation on the testing dataset!")
         with torch.no_grad():
-            for _, test_batch in enumerate(data_loader['test']):
+            for _, test_batch in enumerate(tqdm(data_loader["test"], ncols=80)):
                 batch_size = test_batch[0].shape[0]
                 data, label = test_batch[0].to(
                     self.config.DEVICE), test_batch[1].to(self.config.DEVICE)

--- a/neural_methods/trainer/TscanTrainer.py
+++ b/neural_methods/trainer/TscanTrainer.py
@@ -172,8 +172,9 @@ class TscanTrainer(BaseTrainer):
 
         self.model = self.model.to(self.config.DEVICE)
         self.model.eval()
+        print("Running model evaluation on the testing dataset!")
         with torch.no_grad():
-            for _, test_batch in enumerate(data_loader['test']):
+            for _, test_batch in enumerate(tqdm(data_loader["test"], ncols=80)):
                 batch_size = test_batch[0].shape[0]
                 data_test, labels_test = test_batch[0].to(
                     self.config.DEVICE), test_batch[1].to(self.config.DEVICE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ scikit_learn==1.0.2
 tensorboardX==2.4.1
 tqdm==4.64.0
 mat73==0.59
+ipykernel==6.26.0
+ipywidgets==8.1.1
+retina-face==0.0.13

--- a/tools/preprocessing_viz/viz_preprocessed_data.ipynb
+++ b/tools/preprocessing_viz/viz_preprocessed_data.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "# Specify path to preprocessed dataset folder\n",
-    "preprocessed_dataset_path = '/path/to/preprocessed/dataset/folder'\n"
+    "preprocessed_dataset_path = '/your/preprocessed/dataset/path/here'"
    ]
   },
   {
@@ -74,6 +74,7 @@
     "# Each visualization is done one chunk at a time\n",
     "!pip install natsort\n",
     "!pip install scipy\n",
+    "!pip install ipywidgets\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -298,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.17"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
A (fairly simple) stab at introducing face detection backends into the toolbox. In the future, some additional refactoring of the `BaseLoader.py` file will likely be needed, especially if more backends get added.

Some quantitative results with POS (HC = Haar Cascade, RF = RetinaFace):

UBFC-rPPG with HC:
===Unsupervised Method ( POS ) Predicting ===
100%|███████████████████████████████████████████| 42/42 [01:11<00:00,  1.70s/it]
Used Unsupervised Method: POS
FFT MAE (FFT Label): 3.9969308035714284 +/- 0.994365555673655
FFT RMSE (FFT Label): 7.5831059532071405 +/- 21.649350686623574
FFT MAPE (FFT Label): 3.8622851481891742 +/- 0.9014916191719023
FFT Pearson (FFT Label): 0.9224921893686093 +/- 0.06103444940234774
FFT SNR (FFT Label): -2.3875030222395335 +/- 1.1356165444835469 (dB)

UBFC-rPPG with RF:
===Unsupervised Method ( POS ) Predicting ===
100%|███████████████████████████████████████████| 42/42 [01:19<00:00,  1.90s/it]
Used Unsupervised Method: POS
FFT MAE (FFT Label): 3.0238560267857144 +/- 0.8826602879469477
FFT RMSE (FFT Label): 6.470351690233616 +/- 19.10398129449891
FFT MAPE (FFT Label): 2.910813268130525 +/- 0.7756710295825437
FFT Pearson (FFT Label): 0.9397976039926306 +/- 0.05403250492289589
FFT SNR (FFT Label): -2.531876496531225 +/- 1.0742929175235254 (dB)

PURE with HC:
===Unsupervised Method ( POS ) Predicting ===
100%|███████████████████████████████████████████| 59/59 [02:16<00:00,  2.31s/it]
Used Unsupervised Method: POS
FFT MAE (FFT Label): 3.6720405190677967 +/- 1.4630957700514682
FFT RMSE (FFT Label): 11.822951673836915 +/- 66.86540992165988
FFT MAPE (FFT Label): 7.248782385643253 +/- 3.031084749953558
FFT Pearson (FFT Label): 0.8783814244636281 +/- 0.0633073917079514
FFT SNR (FFT Label): 6.866575820510611 +/- 0.9486667657630489 (dB)

PURE with RF:
===Unsupervised Method ( POS ) Predicting ===
100%|███████████████████████████████████████████| 59/59 [01:36<00:00,  1.63s/it]
Used Unsupervised Method: POS
FFT MAE (FFT Label): 3.0314817266949152 +/- 1.3329728950598538
FFT RMSE (FFT Label): 10.678111680356963 +/- 62.29386026026936
FFT MAPE (FFT Label): 6.087798394258333 +/- 2.79597728460723
FFT Pearson (FFT Label): 0.8999647759432344 +/- 0.05774465906212253
FFT SNR (FFT Label): 6.798964613851172 +/- 0.9636205610753447 (dB)

Some qualitative sample frames:

PURE, with HC:
![Screenshot from 2023-11-29 06-53-54](https://github.com/ubicomplab/rPPG-Toolbox/assets/26243917/b35df2dd-cd36-4a6d-83b4-7875a423dd26)

![Screenshot from 2023-11-29 06-54-58](https://github.com/ubicomplab/rPPG-Toolbox/assets/26243917/1879e7dd-8b1e-4c9f-bf06-95478b879ee4)


PURE, with RF:
![Screenshot from 2023-11-29 06-56-21](https://github.com/ubicomplab/rPPG-Toolbox/assets/26243917/89a3b288-d4ab-4397-89e6-21fe06e5871f)

![Screenshot from 2023-11-29 06-56-44](https://github.com/ubicomplab/rPPG-Toolbox/assets/26243917/36f08e17-349f-4bc7-92da-8b6c0a000e66)

Some additional thoughts from my end:

* Further exploration is needed to find an optimal set of parameters (e.g., whether or not to enlarge the face box, larger box coeff, etc), so I've noted in the README and made it so that Haar Cascade is still used by default across all configs. Users can choose to utilize RetinaFace with a particular dataset at their own discretion. This may especially make a difference when training and testing with neural methods.
* I think there are faster methods that can also be included as a backend at the expense of slightly worse face detection. This may be worth doing if there's every a real-time rPPG demo developed as a part of this toolbox.