### PR TITLE
Correct SNR calculation to reflect reference

### DIFF
--- a/evaluation/post_process.py
+++ b/evaluation/post_process.py
@@ -1,5 +1,5 @@
 """The post processing files for caluclating heart rate using FFT or peak detection.
-The file also  includes helper funcs such as detrend, mag2db etc.
+The file also  includes helper funcs such as detrend, power2db etc.
 """
 
 import numpy as np
@@ -28,9 +28,9 @@ def _detrend(input_signal, lambda_value):
         (H - np.linalg.inv(H + (lambda_value ** 2) * np.dot(D.T, D))), input_signal)
     return detrended_signal
 
-def mag2db(mag):
-    """Convert magnitude to db."""
-    return 20. * np.log10(mag)
+def power2db(mag):
+    """Convert power to db."""
+    return 10 * np.log10(mag)
 
 def _calculate_fft_hr(ppg_signal, fs=60, low_pass=0.75, high_pass=2.5):
     """Calculate heart rate based on PPG using Fast Fourier transform (FFT)."""
@@ -109,13 +109,13 @@ def _calculate_SNR(pred_ppg_signal, hr_label, fs=30, low_pass=0.75, high_pass=2.
     pxx_remainder = pxx_ppg[idx_remainder]
 
     # Calculate the signal power
-    signal_power_hm1 = np.sum(pxx_harmonic1)
-    signal_power_hm2 = np.sum(pxx_harmonic2)
-    signal_power_rem = np.sum(pxx_remainder)
+    signal_power_hm1 = np.sum(pxx_harmonic1**2)
+    signal_power_hm2 = np.sum(pxx_harmonic2**2)
+    signal_power_rem = np.sum(pxx_remainder**2)
 
     # Calculate the SNR as the ratio of the areas
     if not signal_power_rem == 0: # catches divide by 0 runtime warning 
-        SNR = mag2db((signal_power_hm1 + signal_power_hm2) / signal_power_rem)
+        SNR = power2db((signal_power_hm1 + signal_power_hm2) / signal_power_rem)
     else:
         SNR = 0
     return SNR


### PR DESCRIPTION
This PR makes some corrections to the SNR calculation in order to properly reflect the approach used in the CHROM paper, and as mentioned in the bottom of page six of [this paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7899506/pdf/boe-12-1-494.pdf).

Using the `PURE_UBFC-rPPG_TSCAN_BASIC.yaml` for testing, here's results (including SNR) prior to corrections:

FFT MAE (FFT Label): 1.2974330357142858 +/- 0.3951013616658031
FFT RMSE (FFT Label): 2.8704957923240366 +/- 3.0489809798112115
FFT MAPE (FFT Label): 1.500155568072648 +/- 0.4672290826823667
FFT Pearson (FFT Label): 0.9890524988652464 +/- 0.02333192795742126
FFT SNR (FFT Label): 1.4945164762235956 +/- 1.1317032218020173 (dB)

And results after corrections:

FFT MAE (FFT Label): 1.2974330357142858 +/- 0.3951013616658031
FFT RMSE (FFT Label): 2.8704957923240366 +/- 3.0489809798112115
FFT MAPE (FFT Label): 1.500155568072648 +/- 0.4672290826823667
FFT Pearson (FFT Label): 0.9890524988652464 +/- 0.02333192795742126
FFT SNR (FFT Label): 6.641024545844431 +/- 1.1291389587742173 (dB)

This does seem to have a significant effect on the SNR, so I propose in a future iteration of the arXiv that all supplementary results that include SNR should be updated.