### PR TITLE
Update SE calculation for RMSE to be more robust to large squared errors

### DIFF
--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -117,8 +117,13 @@ def calculate_metrics(predictions, labels, config):
                 standard_error = np.std(np.abs(predict_hr_fft_all - gt_hr_fft_all)) / np.sqrt(num_test_samples)
                 print("FFT MAE (FFT Label): {0} +/- {1}".format(MAE_FFT, standard_error))
             elif metric == "RMSE":
-                RMSE_FFT = np.sqrt(np.mean(np.square(predict_hr_fft_all - gt_hr_fft_all)))
-                standard_error = np.std(np.square(predict_hr_fft_all - gt_hr_fft_all)) / np.sqrt(num_test_samples)
+                MSE_FFT = np.mean(np.square(predict_hr_fft_all - gt_hr_fft_all))
+                RMSE_FFT = np.sqrt(MSE_FFT)
+                # In the case of standard error (SE) for RMSE, scale the standard error relative to the RMSE
+                # which is less sensitive to possible outliers. This should prevent the SE from becoming too
+                # large, and exaggerated, due to large, squared errors.
+                MSE_FFT_se = np.std(np.square(predict_hr_fft_all - gt_hr_fft_all)) / np.sqrt(num_test_samples)
+                standard_error = MSE_FFT_se / (2 * np.sqrt(MSE_FFT))
                 print("FFT RMSE (FFT Label): {0} +/- {1}".format(RMSE_FFT, standard_error))
             elif metric == "MAPE":
                 MAPE_FFT = np.mean(np.abs((predict_hr_fft_all - gt_hr_fft_all) / gt_hr_fft_all)) * 100
@@ -167,8 +172,13 @@ def calculate_metrics(predictions, labels, config):
                 standard_error = np.std(np.abs(predict_hr_peak_all - gt_hr_peak_all)) / np.sqrt(num_test_samples)
                 print("Peak MAE (Peak Label): {0} +/- {1}".format(MAE_PEAK, standard_error))
             elif metric == "RMSE":
-                RMSE_PEAK = np.sqrt(np.mean(np.square(predict_hr_peak_all - gt_hr_peak_all)))
-                standard_error = np.std(np.square(predict_hr_peak_all - gt_hr_peak_all)) / np.sqrt(num_test_samples)
+                MSE_PEAK = np.mean(np.square(predict_hr_fft_all - gt_hr_fft_all))
+                RMSE_PEAK = np.sqrt(MSE_PEAK)
+                # In the case of standard error (SE) for RMSE, scale the standard error relative to the RMSE
+                # which is less sensitive to possible outliers. This should prevent the SE from becoming too
+                # large, and exaggerated, due to large, squared errors.
+                MSE_PEAK_se = np.std(np.square(predict_hr_fft_all - gt_hr_fft_all)) / np.sqrt(num_test_samples)
+                standard_error = MSE_PEAK_se / (2 * np.sqrt(MSE_PEAK))
                 print("PEAK RMSE (Peak Label): {0} +/- {1}".format(RMSE_PEAK, standard_error))
             elif metric == "MAPE":
                 MAPE_PEAK = np.mean(np.abs((predict_hr_peak_all - gt_hr_peak_all) / gt_hr_peak_all)) * 100


### PR DESCRIPTION
As the title suggests, this makes the standard error calculation for RMSE more robust to large squared errors. This is done by scaling the the standard error relative to the RMSE, which is less sensitive to possible outliers.