### PR TITLE
Update repo setup to use pip for PyTorch installation and include uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,11 +215,15 @@ The table shows  Mean Absolute Error (MAE) and Mean Absolute Percent Error (MAPE
 
 # :wrench: Setup
 
-STEP 1: `bash setup.sh` 
+You can use either [`conda`](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) or [`uv`](https://docs.astral.sh/uv/getting-started/installation/) with this toolbox. Most users are already familiar with `conda`, but `uv` may be a bit less familiar - check out some highlights about `uv` [here](https://docs.astral.sh/uv/#highlights). If you use `uv`, it's highly recommended you do so independently of `conda`, meaning you should make sure you're not installing anything in the base `conda` environment or any other `conda` environment. If you're having trouble making sure you're not in your base `conda` environment, try setting `conda config --set auto_activate_base false`.
 
-STEP 2: `conda activate rppg-toolbox` 
+STEP 1: `bash setup.sh conda` or `bash setup.sh uv` 
 
-STEP 3: `bash install.sh`
+STEP 2: `conda activate rppg-toolbox` or, when using `uv`, `source .venv/bin/activate`
+
+NOTE: the above setup should work without any issues on machines using Linux or MacOS. If you run into compiler-related issues using `uv` when installing tools related to mamba, try checking to see if `clang++` is in your path using `which clang++`. If nothing shows up, you can install `clang++` using `sudo apt-get install clang` on Linux or `xcode-select --install` on MacOS.
+
+If you use Windows or other operating systems, consider using [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install) and following the steps within `setup.sh` independently.
 
 # :computer: Example of Using Pre-trained Models 
 

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,0 @@
-pip install -r requirements.txt
-cd tools/mamba
-python setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ retina-face==0.0.13
 fsspec==2024.10.0
 timm==1.0.11
 causal-conv1d==1.0.0
+protobuf==3.20.3

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,51 @@
-conda remove --name rppg-toolbox --all -y
-conda create -n rppg-toolbox python=3.8 pytorch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 pytorch-cuda=12.1 -c pytorch -c nvidia -q -y
+#!/bin/bash
+
+# Check if a mode argument is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 {conda|uv}"
+    exit 1
+fi
+
+MODE=$1
+
+# Function to set up using conda
+conda_setup() {
+    echo "Setting up using conda..."
+    conda remove --name rppg-toolbox --all -y || exit 1
+    conda create -n rppg-toolbox python=3.8 -y || exit 1
+    source "$(conda info --base)/etc/profile.d/conda.sh" || exit 1
+    conda activate rppg-toolbox || exit 1
+    pip install torch==2.1.2+cu121 torchvision==0.16.2+cu121 torchaudio==2.1.2+cu121 --index-url https://download.pytorch.org/whl/cu121
+    pip install -r requirements.txt || exit 1
+    cd tools/mamba || exit 1
+    python setup.py install || exit 1
+}
+
+# Function to set up using uv
+uv_setup() {
+    rm -rf .venv || exit 1
+    uv venv --python 3.8 || exit 1
+    source .venv/bin/activate || exit 1
+    uv pip install setuptools wheel || exit 1
+    uv pip install torch==2.1.2+cu121 torchvision==0.16.2+cu121 torchaudio==2.1.2+cu121 --index-url https://download.pytorch.org/whl/cu121 || exit 1
+    uv pip install -r requirements.txt || exit 1
+    cd tools/mamba && python setup.py install || exit 1
+    # Explicitly install PyQt5 to use interactive plotting and avoid non-interactive backends
+    # See this relevant issue for more details: https://github.com/astral-sh/uv/issues/6893
+    uv pip install PyQt5
+}
+
+# Execute the appropriate setup based on the mode
+case $MODE in
+    conda)
+        conda_setup
+        ;;
+    uv)
+        uv_setup
+        ;;
+    *)
+        echo "Invalid mode: $MODE"
+        echo "Usage: $0 {conda|uv}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR does the following:

- Removes usage of the conda channels for PyTorch-related installations. This is in light of the following announcement that suggests, without the change in this PR, issues may occur in the future: https://github.com/pytorch/pytorch/issues/138506
- Adds [`uv`](https://docs.astral.sh/uv/) as an option to manage an environment for the toolbox.

I've tested both `conda` and `uv` environments using this PR and various parts of the toolbox (e.g., training, inference, and visualization of preprocessed data) without any issues. I expect the `conda` usage, which will continue to be used by almost all users in the near-term, to be unaffected, but the `uv` usage by anyone who wants to adopts it may be a bit bumpy given `uv` being relatively new. 