### PR TITLE
fix SNR calculation error

### DIFF
--- a/evaluation/post_process.py
+++ b/evaluation/post_process.py
@@ -109,9 +109,9 @@ def _calculate_SNR(pred_ppg_signal, hr_label, fs=30, low_pass=0.75, high_pass=2.
     pxx_remainder = pxx_ppg[idx_remainder]
 
     # Calculate the signal power
-    signal_power_hm1 = np.sum(pxx_harmonic1**2)
-    signal_power_hm2 = np.sum(pxx_harmonic2**2)
-    signal_power_rem = np.sum(pxx_remainder**2)
+    signal_power_hm1 = np.sum(pxx_harmonic1)
+    signal_power_hm2 = np.sum(pxx_harmonic2)
+    signal_power_rem = np.sum(pxx_remainder)
 
     # Calculate the SNR as the ratio of the areas
     if not signal_power_rem == 0: # catches divide by 0 runtime warning 


### PR DESCRIPTION
According to [scipy.signal.periodogram](https://docs.scipy.org/doc/scipy-1.5.2/reference/generated/scipy.signal.periodogram.html#scipy.signal.periodogram),the signal spectrum that scipy.signal.periodogram returned is represented as a power spectrum, so there is no need for additional power calculations.