### PR TITLE
Fixing the RMSE standard_error calculation in unsupervised_predictor.py

### DIFF
--- a/unsupervised_methods/unsupervised_predictor.py
+++ b/unsupervised_methods/unsupervised_predictor.py
@@ -97,9 +97,10 @@ def unsupervised_predict(config, data_loader, method_name):
                 standard_error = np.std(np.abs(predict_hr_peak_all - gt_hr_peak_all)) / np.sqrt(num_test_samples)
                 print("Peak MAE (Peak Label): {0} +/- {1}".format(MAE_PEAK, standard_error))
             elif metric == "RMSE":
-                RMSE_PEAK = np.sqrt(np.mean(np.square(predict_hr_peak_all - gt_hr_peak_all)))
-                standard_error = np.std(np.square(predict_hr_peak_all - gt_hr_peak_all)) / np.sqrt(num_test_samples)
-                print("PEAK RMSE (Peak Label): {0} +/- {1}".format(RMSE_PEAK, standard_error))
+                squared_errors = np.square(predict_hr_peak_all - gt_hr_peak_all)
+                RMSE_PEAK = np.sqrt(np.mean(squared_errors))
+                standard_error = np.sqrt(np.std(squared_errors) / np.sqrt(num_test_samples))
+                print("PEAK RMSE (PEAK Label): {0} +/- {1}".format(RMSE_PEAK, standard_error))
             elif metric == "MAPE":
                 MAPE_PEAK = np.mean(np.abs((predict_hr_peak_all - gt_hr_peak_all) / gt_hr_peak_all)) * 100
                 standard_error = np.std(np.abs((predict_hr_peak_all - gt_hr_peak_all) / gt_hr_peak_all)) / np.sqrt(num_test_samples) * 100
@@ -145,8 +146,9 @@ def unsupervised_predict(config, data_loader, method_name):
                 standard_error = np.std(np.abs(predict_hr_fft_all - gt_hr_fft_all)) / np.sqrt(num_test_samples)
                 print("FFT MAE (FFT Label): {0} +/- {1}".format(MAE_FFT, standard_error))
             elif metric == "RMSE":
-                RMSE_FFT = np.sqrt(np.mean(np.square(predict_hr_fft_all - gt_hr_fft_all)))
-                standard_error = np.std(np.square(predict_hr_fft_all - gt_hr_fft_all)) / np.sqrt(num_test_samples)
+                squared_errors = np.square(predict_hr_fft_all - gt_hr_fft_all)
+                RMSE_FFT = np.sqrt(np.mean(squared_errors))
+                standard_error = np.sqrt(np.std(squared_errors) / np.sqrt(num_test_samples))
                 print("FFT RMSE (FFT Label): {0} +/- {1}".format(RMSE_FFT, standard_error))
             elif metric == "MAPE":
                 MAPE_FFT = np.mean(np.abs((predict_hr_fft_all - gt_hr_fft_all) / gt_hr_fft_all)) * 100

--- a/unsupervised_methods/unsupervised_predictor.py
+++ b/unsupervised_methods/unsupervised_predictor.py
@@ -97,10 +97,13 @@ def unsupervised_predict(config, data_loader, method_name):
                 standard_error = np.std(np.abs(predict_hr_peak_all - gt_hr_peak_all)) / np.sqrt(num_test_samples)
                 print("Peak MAE (Peak Label): {0} +/- {1}".format(MAE_PEAK, standard_error))
             elif metric == "RMSE":
+                # Calculate the squared errors, then RMSE, in order to allow
+                # for a more robust and intuitive standard error that won't
+                # be influenced by abnormal distributions of errors.
                 squared_errors = np.square(predict_hr_peak_all - gt_hr_peak_all)
                 RMSE_PEAK = np.sqrt(np.mean(squared_errors))
                 standard_error = np.sqrt(np.std(squared_errors) / np.sqrt(num_test_samples))
-                print("PEAK RMSE (PEAK Label): {0} +/- {1}".format(RMSE_PEAK, standard_error))
+                print("PEAK RMSE (Peak Label): {0} +/- {1}".format(RMSE_PEAK, standard_error))
             elif metric == "MAPE":
                 MAPE_PEAK = np.mean(np.abs((predict_hr_peak_all - gt_hr_peak_all) / gt_hr_peak_all)) * 100
                 standard_error = np.std(np.abs((predict_hr_peak_all - gt_hr_peak_all) / gt_hr_peak_all)) / np.sqrt(num_test_samples) * 100
@@ -146,6 +149,9 @@ def unsupervised_predict(config, data_loader, method_name):
                 standard_error = np.std(np.abs(predict_hr_fft_all - gt_hr_fft_all)) / np.sqrt(num_test_samples)
                 print("FFT MAE (FFT Label): {0} +/- {1}".format(MAE_FFT, standard_error))
             elif metric == "RMSE":
+                # Calculate the squared errors, then RMSE, in order to allow
+                # for a more robust and intuitive standard error that won't
+                # be influenced by abnormal distributions of errors.
                 squared_errors = np.square(predict_hr_fft_all - gt_hr_fft_all)
                 RMSE_FFT = np.sqrt(np.mean(squared_errors))
                 standard_error = np.sqrt(np.std(squared_errors) / np.sqrt(num_test_samples))


### PR DESCRIPTION
The square root was missing in standard_error calculation.