### PR TITLE
Update testing chunk length in DeepPhysTrainer.py

### DIFF
--- a/neural_methods/trainer/DeepPhysTrainer.py
+++ b/neural_methods/trainer/DeepPhysTrainer.py
@@ -142,7 +142,7 @@ class DeepPhysTrainer(BaseTrainer):
         config = self.config
 
         # Change chunk length to be test chunk length
-        self.chunk_len = self.config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+        self.chunk_len = config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
         
         print('')
         print("===Testing===")

--- a/neural_methods/trainer/DeepPhysTrainer.py
+++ b/neural_methods/trainer/DeepPhysTrainer.py
@@ -24,7 +24,7 @@ class DeepPhysTrainer(BaseTrainer):
         self.model_dir = config.MODEL.MODEL_DIR
         self.model_file_name = config.TRAIN.MODEL_FILE_NAME
         self.batch_size = config.TRAIN.BATCH_SIZE
-        self.chunk_len = config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
         self.config = config
         self.min_valid_loss = None
         self.best_epoch = 0
@@ -140,6 +140,9 @@ class DeepPhysTrainer(BaseTrainer):
         if data_loader["test"] is None:
             raise ValueError("No data for test")
         config = self.config
+
+        # Change chunk length to be test chunk length
+        self.chunk_len = self.config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
         
         print('')
         print("===Testing===")

--- a/neural_methods/trainer/DeepPhysTrainer.py
+++ b/neural_methods/trainer/DeepPhysTrainer.py
@@ -24,7 +24,7 @@ class DeepPhysTrainer(BaseTrainer):
         self.model_dir = config.MODEL.MODEL_DIR
         self.model_file_name = config.TRAIN.MODEL_FILE_NAME
         self.batch_size = config.TRAIN.BATCH_SIZE
-        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
+        self.chunk_len = config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
         self.config = config
         self.min_valid_loss = None
         self.best_epoch = 0


### PR DESCRIPTION
The chunk_len parameter is used inside testing function. However, it was being loaded from the training preprocessing parameters like this:
`        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
`

This meant the chunk_len defined in the testing section of the config files were not being used. Specially, for inference configs, the code was ignoring the testing section parameters and was using the default training chunk length of 180.
For example, when running the "./infer configs/PURE_UBFC-PHYS_DEEPPHYS_BASIC.yaml" file, it is defined --> CHUNK_LENGTH: 210.

However, the code was using length of 180. 


