### PR TITLE
Add fixes for test-time chunk length

### DIFF
--- a/neural_methods/trainer/DeepPhysTrainer.py
+++ b/neural_methods/trainer/DeepPhysTrainer.py
@@ -143,6 +143,10 @@ class DeepPhysTrainer(BaseTrainer):
         
         print('')
         print("===Testing===")
+
+        # Change chunk length to be test chunk length
+        self.chunk_len = self.config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+
         predictions = dict()
         labels = dict()
         if self.config.TOOLBOX_MODE == "only_test":

--- a/neural_methods/trainer/EfficientPhysTrainer.py
+++ b/neural_methods/trainer/EfficientPhysTrainer.py
@@ -157,6 +157,10 @@ class EfficientPhysTrainer(BaseTrainer):
 
         print('')
         print("===Testing===")
+
+        # Change chunk length to be test chunk length
+        self.chunk_len = self.config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+
         predictions = dict()
         labels = dict()
 

--- a/neural_methods/trainer/PhysFormerTrainer.py
+++ b/neural_methods/trainer/PhysFormerTrainer.py
@@ -41,13 +41,13 @@ class PhysFormerTrainer(BaseTrainer):
         self.model_file_name = config.TRAIN.MODEL_FILE_NAME
         self.batch_size = config.TRAIN.BATCH_SIZE
         self.num_of_gpu = config.NUM_OF_GPU_TRAIN
-        self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
         self.frame_rate = config.TRAIN.DATA.FS
         self.config = config 
         self.min_valid_loss = None
         self.best_epoch = 0
 
         if config.TOOLBOX_MODE == "train_and_test":
+            self.chunk_len = config.TRAIN.DATA.PREPROCESS.CHUNK_LENGTH
             self.model = ViT_ST_ST_Compact3_TDC_gra_sharp(
                 image_size=(self.chunk_len,config.TRAIN.DATA.PREPROCESS.RESIZE.H,config.TRAIN.DATA.PREPROCESS.RESIZE.W), 
                 patches=(self.patch_size,) * 3, dim=self.dim, ff_dim=self.ff_dim, num_heads=self.num_heads, num_layers=self.num_layers, 
@@ -65,6 +65,7 @@ class PhysFormerTrainer(BaseTrainer):
             # of using StepLR in the first place. Consider investigating and using another approach (e.g., OneCycleLR).
             self.scheduler = optim.lr_scheduler.StepLR(self.optimizer, step_size=50, gamma=0.5)
         elif config.TOOLBOX_MODE == "only_test":
+            self.chunk_len = config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
             self.model = ViT_ST_ST_Compact3_TDC_gra_sharp(
                 image_size=(self.chunk_len,config.TRAIN.DATA.PREPROCESS.RESIZE.H,config.TRAIN.DATA.PREPROCESS.RESIZE.W), 
                 patches=(self.patch_size,) * 3, dim=self.dim, ff_dim=self.ff_dim, num_heads=self.num_heads, num_layers=self.num_layers, 
@@ -207,6 +208,10 @@ class PhysFormerTrainer(BaseTrainer):
         
         print('')
         print("===Testing===")
+
+        # Change chunk length to be test chunk length
+        self.chunk_len = self.config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+
         predictions = dict()
         labels = dict()
 

--- a/neural_methods/trainer/RhythmFormerTrainer.py
+++ b/neural_methods/trainer/RhythmFormerTrainer.py
@@ -123,6 +123,10 @@ class RhythmFormerTrainer(BaseTrainer):
 
         print('')
         print("===Testing===")
+
+        # Change chunk length to be test chunk length
+        self.chunk_len = self.config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+
         if self.config.TOOLBOX_MODE == "only_test":
             if not os.path.exists(self.config.INFERENCE.MODEL_PATH):
                 raise ValueError("Inference model path error! Please check INFERENCE.MODEL_PATH in your yaml.")

--- a/neural_methods/trainer/TscanTrainer.py
+++ b/neural_methods/trainer/TscanTrainer.py
@@ -148,6 +148,10 @@ class TscanTrainer(BaseTrainer):
 
         print('')
         print("===Testing===")
+
+        # Change chunk length to be test chunk length
+        self.chunk_len = self.config.TEST.DATA.PREPROCESS.CHUNK_LENGTH
+
         predictions = dict()
         labels = dict()
 


### PR DESCRIPTION
Akin to how `BigSmallTrainer.py` does it, these fixes make it so that, where relevant, the test-time chunk length config parameter is appropriately used. This likely didn't pop up as an issue since most folks would likely want to use the same chunk length as used during training, but I believe these fixes achieve the flexibility we were aiming for originally with the separate config parameters.

It should be noted that some trainer files are unaffected because they either use a frame num config parameter to control the temporal structure when instantiating a model (e.g., PhysNet and iBVPNet) or they operate on the entire input sequence (e.g., PhysMamba).