### PR TITLE
RhythmFormer and PhysMamba fixes

### DIFF
--- a/configs/infer_configs/PURE_MMPD_PHYSMAMBA.yaml
+++ b/configs/infer_configs/PURE_MMPD_PHYSMAMBA.yaml
@@ -31,7 +31,7 @@ VALID:
         H: 128
         W: 128
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     INFO:

--- a/configs/infer_configs/PURE_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/PURE_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -1,7 +1,7 @@
 BASE: ['']
 TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     INFO:

--- a/configs/infer_configs/PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
@@ -1,7 +1,7 @@
 BASE: ['']
 TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     FS: 30

--- a/configs/infer_configs/PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
+++ b/configs/infer_configs/PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
@@ -21,6 +21,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_MMPD_PHYSMAMBA_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_MMPD_PHYSMAMBA_BASIC.yaml
@@ -31,7 +31,7 @@ VALID:
         H: 128
         W: 128
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     INFO:

--- a/configs/infer_configs/UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -29,6 +29,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/infer_configs/UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -1,7 +1,7 @@
 BASE: ['']
 TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     INFO:

--- a/configs/infer_configs/UBFC-rPPG_PURE_RHYTHMFORMER.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_RHYTHMFORMER.yaml
@@ -20,6 +20,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/infer_configs/UBFC-rPPG_PURE_RHYTHMFORMER.yaml
+++ b/configs/infer_configs/UBFC-rPPG_PURE_RHYTHMFORMER.yaml
@@ -1,7 +1,7 @@
 BASE: ['']
 TOOLBOX_MODE: "only_test"      # "train_and_test"  or "only_test"
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     FS: 30

--- a/configs/train_configs/PURE_PURE_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -5,7 +5,7 @@ TRAIN:
   EPOCHS: 30
   LR: 9e-3
   MODEL_FILE_NAME: PURE_UBFC_RhythmFormer
-  AUG: 1
+  PLOT_LOSSES_AND_LR: True
   DATA:
     FS: 30
     DATASET: PURE
@@ -18,11 +18,13 @@ TRAIN:
     END: 0.8
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -45,11 +47,13 @@ VALID:
     END: 1.0
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -88,6 +92,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -64,7 +64,7 @@ VALID:
         H: 128
         W: 128
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     INFO:

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
@@ -5,7 +5,7 @@ TRAIN:
   EPOCHS: 30
   LR: 9e-3
   MODEL_FILE_NAME: PURE_UBFC_RhythmFormer
-  AUG: 1
+  PLOT_LOSSES_AND_LR: True
   DATA:
     FS: 30
     DATASET: PURE
@@ -18,11 +18,13 @@ TRAIN:
     END: 0.8
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -45,11 +47,13 @@ VALID:
     END: 1.0
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/PURE_PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/PURE_PURE_UBFC-rPPG_RHYTHMFORMER_BASIC.yaml
@@ -64,7 +64,7 @@ VALID:
         H: 128
         W: 128
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     FS: 30

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -5,7 +5,7 @@ TRAIN:
   EPOCHS: 30
   LR: 9e-3
   MODEL_FILE_NAME: UBFC_MMPD_RhythmFormer
-  AUG: 1
+  PLOT_LOSSES_AND_LR: True
   DATA:
     FS: 30
     DATASET: UBFC-rPPG
@@ -18,11 +18,13 @@ TRAIN:
     END: 0.8
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -45,11 +47,13 @@ VALID:
     END: 1.0
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -88,6 +92,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_MMPD_RHYTHMFORMER_BASIC.yaml
@@ -64,7 +64,7 @@ VALID:
         H: 128
         W: 128
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     INFO:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSMAMBA.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_PHYSMAMBA.yaml
@@ -99,7 +99,7 @@ TEST:
 DEVICE: cuda:0
 NUM_OF_GPU_TRAIN: 1
 LOG:
-  PATH: /data
+  PATH: runs/exp
 MODEL:
   NAME: PhysMamba
 INFERENCE:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_RHYTHMFORMER_BASIC.yaml
@@ -5,7 +5,7 @@ TRAIN:
   EPOCHS: 30
   LR: 9e-3
   MODEL_FILE_NAME: UBFC_PURE_RhythmFormer
-  AUG: 1
+  PLOT_LOSSES_AND_LR: True
   DATA:
     FS: 30
     DATASET: UBFC-rPPG
@@ -18,11 +18,13 @@ TRAIN:
     END: 0.8
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -45,11 +47,13 @@ VALID:
     END: 1.0
     PREPROCESS :
       DATA_TYPE: ['Standardized']
+      DATA_AUG: ['None']    # 'None' or 'Motion' is supported, used if the data path points to an augmented dataset or requires augmentation
       LABEL_TYPE: Standardized
       DO_CHUNK: True
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:
@@ -79,6 +83,7 @@ TEST:
       CHUNK_LENGTH: 160
       CROP_FACE:
         DO_CROP_FACE: True
+        BACKEND: 'HC'    # HC for Haar Cascade, RF for RetinaFace
         USE_LARGE_FACE_BOX: True
         LARGE_BOX_COEF: 1.5
         DETECTION:

--- a/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_RHYTHMFORMER_BASIC.yaml
+++ b/configs/train_configs/UBFC-rPPG_UBFC-rPPG_PURE_RHYTHMFORMER_BASIC.yaml
@@ -64,7 +64,7 @@ VALID:
         H: 128
         W: 128
 TEST:
-  METRICS: ['MAE','RMSE','MAPE','Pearson','SNR']
+  METRICS: ['MAE', 'RMSE', 'MAPE', 'Pearson', 'SNR', 'BA']
   USE_LAST_EPOCH: False                      # to use provided validation dataset to find the best epoch, should be false
   DATA:
     FS: 30


### PR DESCRIPTION
The following changes were made as a result of an investigation of issue #368:

* Some code for logging and saving plots for learning rate and loss information, as well as saving model outputs, was missing from `RhythmFormerTrainer.py`. This has been fixed alongside some minor changes to the corresponding config files to remove an erroneous `AUG` parameter and add in some missing parameters. 
* For one PhysMamba config file, the log path was different from every other config file. This has been corrected.
* For some RhythmFormer and PhysMamba config files, Bland-Altman Plot generation has been enabled by default just like the other configs.