### PR TITLE
Add run directory creation, logging setup, and unified output saving

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@
 import argparse
 import random
 import time
+import os
+import sys
+import logging
+from datetime import datetime
 
 import numpy as np
 import torch

--- a/main.py
+++ b/main.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
     sys.stderr = Tee(sys.stderr, logfile)
 
     # configurations.
-    config = get_config(args)
+    # config = get_config(args)
     print('------------------Model training --------------------------')
     print('Configuration:')
     print(config, end='\n\n')

--- a/main.py
+++ b/main.py
@@ -146,13 +146,6 @@ def setup_run_dir(base_dir, model_name):
         os.makedirs(checkpoint_dir, exist_ok=True)
         log_file = os.path.join(run_dir, "training.log")
         return run_dir, checkpoint_dir, log_file
-    
-def setup_logger(log_file_path):
-    logging.basicConfig(level=logging.INFO,
-                        format='%(asctime)s - %(levelname)s - %(message)s',
-                        handlers=[logging.StreamHandler(),
-                                logging.FileHandler(log_file_path)])
-    return logging.getLogger(__name__)
 class Tee(object):
         def __init__(self, *files):
             self.files = files

--- a/main.py
+++ b/main.py
@@ -137,17 +137,62 @@ def unsupervised_method_inference(config, data_loader):
         else:
             raise ValueError("Not supported unsupervised method!")
 
+def setup_run_dir(base_dir, model_name):
+        """Create a unique run directory for this training session."""
+        current_time = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_dir = os.path.join(base_dir, f"{model_name}_{current_time}")
+        os.makedirs(run_dir, exist_ok=True)
+        checkpoint_dir = os.path.join(run_dir, "checkpoints")
+        os.makedirs(checkpoint_dir, exist_ok=True)
+        log_file = os.path.join(run_dir, "training.log")
+        return run_dir, checkpoint_dir, log_file
+    
+def setup_logger(log_file_path):
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s - %(levelname)s - %(message)s',
+                        handlers=[logging.StreamHandler(),
+                                logging.FileHandler(log_file_path)])
+    return logging.getLogger(__name__)
+class Tee(object):
+        def __init__(self, *files):
+            self.files = files
+
+        def write(self, obj):
+            for f in self.files:
+                f.write(obj)
+                f.flush()
+
+        def flush(self):
+            for f in self.files:
+                f.flush()
+
 
 if __name__ == "__main__":
     # parse arguments.
+    global logger
     parser = argparse.ArgumentParser()
     parser = add_args(parser)
     parser = trainer.BaseTrainer.BaseTrainer.add_trainer_args(parser)
     parser = data_loader.BaseLoader.BaseLoader.add_data_loader_args(parser)
     args = parser.parse_args()
+    
+    config = get_config(args)
+    run_dir, checkpoint_dir, log_file = setup_run_dir('runs', config.MODEL.NAME)
+
+    config.defrost()
+    config.LOG.PATH = run_dir  # Update config with the new run directory
+    config.MODEL.MODEL_DIR = checkpoint_dir  # Update config with the new checkpoint directory
+    config.freeze() 
+    
+    logfile = open(log_file, "a")
+
+    # Send print output to both console and file
+    sys.stdout = Tee(sys.stdout, logfile)
+    sys.stderr = Tee(sys.stderr, logfile)
 
     # configurations.
     config = get_config(args)
+    print('------------------Model training --------------------------')
     print('Configuration:')
     print(config, end='\n\n')
 

--- a/neural_methods/trainer/BaseTrainer.py
+++ b/neural_methods/trainer/BaseTrainer.py
@@ -28,7 +28,7 @@ class BaseTrainer:
 
     def save_test_outputs(self, predictions, labels, config):
     
-        output_dir = config.TEST.OUTPUT_SAVE_DIR
+        output_dir = config.LOG.PATH + "/outputs"
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
         


### PR DESCRIPTION
This PR introduces a structured run directory system and logging pipeline to improve experiment reproducibility and debugging.

Key updates:
- Added `setup_run_dir()` to generate timestamped run folders with a dedicated `checkpoints/` subdirectory.
- Added `setup_logger()` to configure both console and file logging.
- The log file (`training.log`) is stored directly in the run directory for simplicity and quick access.
- Redirected stdout and stderr using a Tee class so all console output is captured in the log file.
- Updated config paths (`LOG.PATH, MODEL.MODEL_DIR`) to use the new run directory.
- Modified save_test_outputs() to store outputs under `<run_dir>/outputs/`.
- Minor cleanup and consistency improvements.

This structure keeps each run self-contained while avoiding unnecessary nesting of log files.
